### PR TITLE
ci: skip codecov upload for fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,7 @@ jobs:
           "
 
       - name: Upload coverage to Codecov
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v4
         with:
           use_oidc: true


### PR DESCRIPTION
## Summary

- Fork PRs cannot obtain an OIDC token from GitHub Actions (security restriction), causing the Codecov upload step to always fail with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`
- Add an `if` condition to skip the step when the PR originates from a fork

## Why this matters

All external contributor PRs were showing a red CI check despite all tests passing, which is noisy and misleading.

## Behavior after this fix

| Trigger | Codecov upload |
|---|---|
| Push to `main` | ✅ runs |
| PR from same repo | ✅ runs |
| PR from fork | ⏭ skipped (tests still run and pass) |