### PR TITLE
Add Claude Code session initialization hooks

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web; skip on local machines.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+echo "[openboot session-start] Go version: $(go version)"
+
+# Pre-fetch and verify Go module deps so tests/builds are fast and offline-safe.
+echo "[openboot session-start] Downloading Go modules..."
+go mod download
+
+# Warm the build cache so the first `go build` / `go test` is fast.
+echo "[openboot session-start] Warming build cache (go build ./...)..."
+go build ./... >/dev/null
+
+# Warm the test binary cache without executing tests.
+echo "[openboot session-start] Warming test cache (go test -count=0 ./...)..."
+go test -count=0 ./... >/dev/null
+
+echo "[openboot session-start] Done."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,10 @@ __pycache__/
 
 # Work tracking (internal)
 .sisyphus/
-.claude/
+.claude/*
+!.claude/hooks/
+!.claude/settings.json
+.claude/settings.local.json
 
 # Go vendor (deps downloaded at build time)
 vendor/


### PR DESCRIPTION
## What does this PR do?

Add session initialization hooks that pre-warm Go build and test caches when starting a Claude Code session on the web, improving performance for subsequent builds and tests.

## Why?

When working in Claude Code on the web, the first `go build` or `go test` commands can be slow because the build cache is cold. By pre-fetching dependencies and warming the build/test caches during session startup, we can make the initial developer experience faster and ensure tests/builds work offline.

This only runs in Claude Code on the web (via the `CLAUDE_CODE_REMOTE` environment variable) and is skipped on local machines.

## Testing

N/A - This is a configuration change that only affects Claude Code web sessions. The hook script is straightforward shell commands that mirror standard Go workflows.

## Notes for reviewer

- The `.claude/` directory is now partially tracked in git (hooks and settings) while still ignoring local overrides (`.claude/settings.local.json`) and other generated files
- The session-start hook only executes in Claude Code remote environments to avoid unnecessary overhead on local development machines

https://claude.ai/code/session_01PeXAW2DA8BnTmFvStfNmWn