### PR TITLE
Change default auto-update mode from Enabled to Notify

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -52,8 +52,13 @@ type UserConfig struct {
 	AutoUpdate AutoUpdateMode `json:"autoupdate"`
 }
 
+// LoadUserConfig returns the user's update preference from
+// ~/.openboot/config.json. The default is AutoUpdateNotify: we surface a
+// one-line "new version available" message but never auto-upgrade the binary
+// during a normal command. Users who want silent upgrades can opt in by
+// setting "autoupdate": "true"; users who want silence can set "false".
 func LoadUserConfig() UserConfig {
-	cfg := UserConfig{AutoUpdate: AutoUpdateEnabled}
+	cfg := UserConfig{AutoUpdate: AutoUpdateNotify}
 	path, err := getUserConfigPath()
 	if err != nil {
 		return cfg
@@ -66,7 +71,7 @@ func LoadUserConfig() UserConfig {
 		return cfg
 	}
 	if cfg.AutoUpdate == "" {
-		cfg.AutoUpdate = AutoUpdateEnabled
+		cfg.AutoUpdate = AutoUpdateNotify
 	}
 	return cfg
 }
@@ -98,15 +103,16 @@ func IsHomebrewInstall() bool {
 	return isHomebrewPath(exe)
 }
 
-// AutoUpgrade checks for a newer version and upgrades if appropriate.
+// AutoUpgrade checks for a newer version and, by default, only prints a notice.
+// Silent self-upgrades are opt-in via ~/.openboot/config.json.
 //
 // Flow:
 //  1. Kill switch: OPENBOOT_DISABLE_AUTOUPDATE=1
 //  2. Dev guard: currentVersion == "dev"
 //  3. UserConfig (applies to ALL install methods):
-//     disabled → exit, notify → show message, enabled → upgrade
+//     disabled → exit, notify (default) → show message, enabled → upgrade
 //  4. resolveLatestVersion: uses 24h cache, falls back to sync GitHub API
-//  5. Upgrade method: Homebrew → brew upgrade, Direct → download binary
+//  5. Upgrade method (enabled mode only): Homebrew → brew upgrade, Direct → download binary
 func AutoUpgrade(currentVersion string) {
 	if os.Getenv("OPENBOOT_DISABLE_AUTOUPDATE") == "1" {
 		return

--- a/internal/updater/updater_extra_test.go
+++ b/internal/updater/updater_extra_test.go
@@ -250,13 +250,13 @@ func TestIsNewerVersion_ExtendedCases(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// LoadUserConfig — AutoUpdate empty field defaults to Enabled
+// LoadUserConfig — AutoUpdate empty field defaults to Notify
 // ---------------------------------------------------------------------------
 
 func TestLoadUserConfig_DefaultWhenMissing(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	cfg := LoadUserConfig()
-	assert.Equal(t, AutoUpdateEnabled, cfg.AutoUpdate)
+	assert.Equal(t, AutoUpdateNotify, cfg.AutoUpdate)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -212,7 +212,7 @@ func TestGetUserConfigPath(t *testing.T) {
 func TestLoadUserConfig_Default_NoFile(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	cfg := LoadUserConfig()
-	assert.Equal(t, AutoUpdateEnabled, cfg.AutoUpdate)
+	assert.Equal(t, AutoUpdateNotify, cfg.AutoUpdate)
 }
 
 func TestLoadUserConfig_FromFile(t *testing.T) {
@@ -236,7 +236,7 @@ func TestLoadUserConfig_InvalidJSON(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte("{bad json"), 0644))
 
 	cfg := LoadUserConfig()
-	assert.Equal(t, AutoUpdateEnabled, cfg.AutoUpdate)
+	assert.Equal(t, AutoUpdateNotify, cfg.AutoUpdate)
 }
 
 func TestLoadUserConfig_EmptyAutoUpdate(t *testing.T) {
@@ -247,7 +247,7 @@ func TestLoadUserConfig_EmptyAutoUpdate(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"autoupdate":""}`), 0644))
 
 	cfg := LoadUserConfig()
-	assert.Equal(t, AutoUpdateEnabled, cfg.AutoUpdate)
+	assert.Equal(t, AutoUpdateNotify, cfg.AutoUpdate)
 }
 
 func TestLoadUserConfig_DisabledMode(t *testing.T) {

--- a/test/integration/updater_integration_test.go
+++ b/test/integration/updater_integration_test.go
@@ -83,8 +83,8 @@ func TestIntegration_Updater_LoadUserConfig_Default(t *testing.T) {
 	// When: we load user config
 	cfg := updater.LoadUserConfig()
 
-	// Then: defaults to auto-update enabled
-	assert.Equal(t, updater.AutoUpdateEnabled, cfg.AutoUpdate)
+	// Then: defaults to notify-only (no silent self-upgrades).
+	assert.Equal(t, updater.AutoUpdateNotify, cfg.AutoUpdate)
 }
 
 func TestIntegration_Updater_LoadUserConfig_AllModes(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Changes the default auto-update behavior from `AutoUpdateEnabled` (silent self-upgrades) to `AutoUpdateNotify` (notification-only), making opt-in the requirement for automatic binary upgrades.

## Why?

This is a safer default that respects user expectations. By default, the tool will now only notify users of available updates with a one-line message rather than silently upgrading the binary during normal command execution. Users who want automatic upgrades can explicitly opt in via `~/.openboot/config.json` by setting `"autoupdate": "true"`.

The change affects:
- Default configuration when no config file exists
- Fallback behavior when config file has an empty `autoupdate` field
- Documentation/comments clarifying the three modes: disabled (exit), notify (default, show message), and enabled (auto-upgrade)

## Testing

- [ ] `go vet ./...` passes
- [ ] All existing tests updated to reflect new default (4 test files, 5 test cases)
- [ ] No new functionality added, only default value changed

## Notes for reviewer

This is a breaking change in default behavior, but improves safety by making automatic upgrades opt-in rather than opt-out. The three-mode system (disabled/notify/enabled) is now clearly documented in the `AutoUpgrade` function comments.

https://claude.ai/code/session_015VgeJBTC58UsLNE1gpwUYe