### PR TITLE
Simplify self-update command from 'openboot update --self' to 'openboot update'

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -183,7 +183,7 @@ func notifyUpdate(currentVersion, latestVersion string) {
 	if IsHomebrewInstall() {
 		ui.Muted("Run 'brew upgrade openboot' to upgrade")
 	} else {
-		ui.Muted("Run 'openboot update --self' to upgrade")
+		ui.Muted("Run 'openboot update' to upgrade")
 	}
 	fmt.Println()
 }
@@ -239,7 +239,7 @@ func doDirectUpgrade(currentVersion, latestVersion string) {
 	ui.Info(fmt.Sprintf("Updating OpenBoot v%s → v%s...", currentClean, latestClean))
 	if err := DownloadAndReplace(latestVersion, currentVersion); err != nil {
 		ui.Warn(fmt.Sprintf("Auto-update failed: %v", err))
-		ui.Muted("Run 'openboot update --self' to update manually")
+		ui.Muted("Run 'openboot update' to update manually")
 		fmt.Println()
 		return
 	}


### PR DESCRIPTION
## What does this PR do?

Updates user-facing messages to reflect the simplified self-update command syntax, removing the `--self` flag from upgrade instructions.

## Why?

The `--self` flag appears to be redundant or has been removed from the command interface. This change simplifies the user experience by providing the correct, shorter command syntax in help messages and error notifications.

## Testing

- [ ] `go vet ./...` passes
- [ ] Tested locally by triggering update notifications and upgrade failures to verify correct messages are displayed

## Notes for reviewer

This is a straightforward documentation/messaging update affecting two user-facing strings in the updater module. No functional logic changes are involved.

https://claude.ai/code/session_0149hb3rTyU8APZ8TNRUbBvg