### PR TITLE
fix(publish): route publish status messages to stderr

### DIFF
--- a/internal/cli/snapshot_publish.go
+++ b/internal/cli/snapshot_publish.go
@@ -50,10 +50,10 @@ func publishSnapshot(ctx context.Context, snap *snapshot.Snapshot, explicitSlug 
 	var configName, configDesc, visibility string
 	if targetSlug != "" {
 		fmt.Fprintln(os.Stderr)
-		ui.Info(fmt.Sprintf("Publishing to @%s/%s (updating)", stored.Username, targetSlug))
+		fmt.Fprintf(os.Stderr, "  Publishing to @%s/%s (updating)\n", stored.Username, targetSlug)
 	} else {
 		fmt.Fprintln(os.Stderr)
-		ui.Info("Publishing as a new config on openboot.dev")
+		fmt.Fprintln(os.Stderr, "  Publishing as a new config on openboot.dev")
 		configName, configDesc, visibility, err = promptPushDetails("")
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

Fixes the destructive-test gate in the release workflow, which has been blocking releases since v0.55.1 (run [24733624876](https://github.com/openbootdotdev/openboot/actions/runs/24733624876/job/72354521082) was the v0.55.2 failure).

`TestE2E_Publish_UpdateViaSyncSource` ([test/e2e/publish_import_e2e_test.go:234](https://github.com/openbootdotdev/openboot/blob/main/test/e2e/publish_import_e2e_test.go#L234)) asserts the `Publishing to @user/slug (updating)` message lands on stderr, but `ui.Info` prints via `fmt.Println` to **stdout**. The surrounding blank-line writes and the final `✓ Config published successfully!` marker already use `os.Stderr`, so the two `ui.Info` calls were the lone stream mismatch.

Fix: write both publish-status lines directly to `os.Stderr`, matching the rest of the publish output stream.

## Test plan

- [ ] CI `gate-tests` → Destructive tests step passes on macos-latest
- [ ] Manual: `openboot snapshot --publish` (with a saved sync source) still shows the "Publishing to @…" line to the user