### PR TITLE
fix(test): run subprocess before reading stdout/stderr buffers

### DIFF
--- a/internal/cli/snapshot_publish.go
+++ b/internal/cli/snapshot_publish.go
@@ -50,10 +50,10 @@ func publishSnapshot(ctx context.Context, snap *snapshot.Snapshot, explicitSlug 
 	var configName, configDesc, visibility string
 	if targetSlug != "" {
 		fmt.Fprintln(os.Stderr)
-		ui.Info(fmt.Sprintf("Publishing to @%s/%s (updating)", stored.Username, targetSlug))
+		fmt.Fprintf(os.Stderr, "  Publishing to @%s/%s (updating)\n", stored.Username, targetSlug)
 	} else {
 		fmt.Fprintln(os.Stderr)
-		ui.Info("Publishing as a new config on openboot.dev")
+		fmt.Fprintln(os.Stderr, "  Publishing as a new config on openboot.dev")
 		configName, configDesc, visibility, err = promptPushDetails("")
 		if err != nil {
 			return err

--- a/test/e2e/publish_import_e2e_test.go
+++ b/test/e2e/publish_import_e2e_test.go
@@ -153,7 +153,8 @@ func runBinary(t *testing.T, binary string, env []string, args ...string) (stdou
 	var outBuf, errBuf strings.Builder
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
-	return outBuf.String(), errBuf.String(), cmd.Run()
+	err = cmd.Run()
+	return outBuf.String(), errBuf.String(), err
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the persistent `TestE2E_Publish_UpdateViaSyncSource` failure that has blocked every release since v0.55.1.

**Root cause:** `runBinary` had a subtle Go evaluation-order bug:

```go
// BEFORE — wrong
return outBuf.String(), errBuf.String(), cmd.Run()
```

Go evaluates return expressions left-to-right, so `outBuf.String()` and `errBuf.String()` were captured **before** `cmd.Run()` executed the subprocess. Both always returned `""`.

```go
// AFTER — correct
err = cmd.Run()
return outBuf.String(), errBuf.String(), err
```

**Why the test failed:** `TestE2E_Publish_UpdateViaSyncSource` asserts `assert.Contains(t, stderr, "bob/my-env")` — but stderr was always `""` regardless of what the binary printed. The companion fix in the prior commit (routing the banner to `os.Stderr`) is correct and still needed; this commit makes the test actually capable of observing it.

## Test plan

- [ ] CI `gate-tests` → Destructive tests passes on macos-latest
- [ ] `TestE2E_Publish_UpdateViaSyncSource` passes