### PR TITLE
Skip socket files in backup conflicts check

### DIFF
--- a/internal/dotfiles/dotfiles.go
+++ b/internal/dotfiles/dotfiles.go
@@ -315,7 +315,8 @@ func backupConflicts(pkgDir, targetDir string) ([][2]string, error) {
 			// Target doesn't exist or is already a symlink — no conflict.
 			return nil
 		}
-		if info.IsDir() {
+		if !info.Mode().IsRegular() {
+			// Skip non-regular files (directories, sockets, named pipes, devices, etc.).
 			return nil
 		}
 

--- a/internal/dotfiles/dotfiles_test.go
+++ b/internal/dotfiles/dotfiles_test.go
@@ -566,17 +566,22 @@ func TestBackupConflicts_SkipsSymlinks(t *testing.T) {
 }
 
 func TestBackupConflicts_SkipsSocketFiles(t *testing.T) {
-	tmpDir := t.TempDir()
+	// Use os.MkdirTemp with an empty dir so the path stays short.
+	// macOS enforces a 104-byte limit on Unix socket paths; t.TempDir() embeds
+	// the full test name and can exceed that limit, causing net.Listen to fail.
+	tmpDir, err := os.MkdirTemp("", "ob")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
 
 	pkgDir := filepath.Join(tmpDir, "pkg")
 	require.NoError(t, os.MkdirAll(pkgDir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agent.sock"), []byte("new"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "s.sock"), []byte("new"), 0644))
 
 	targetDir := filepath.Join(tmpDir, "home")
 	require.NoError(t, os.MkdirAll(targetDir, 0755))
 
 	// Create a Unix domain socket at the conflict path.
-	socketPath := filepath.Join(targetDir, "agent.sock")
+	socketPath := filepath.Join(targetDir, "s.sock")
 	ln, err := net.Listen("unix", socketPath)
 	require.NoError(t, err)
 	defer ln.Close()

--- a/internal/dotfiles/dotfiles_test.go
+++ b/internal/dotfiles/dotfiles_test.go
@@ -1,6 +1,7 @@
 package dotfiles
 
 import (
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -562,6 +563,27 @@ func TestBackupConflicts_SkipsSymlinks(t *testing.T) {
 	backed, err := backupConflicts(pkgDir, targetDir)
 	require.NoError(t, err)
 	assert.Len(t, backed, 0)
+}
+
+func TestBackupConflicts_SkipsSocketFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkgDir := filepath.Join(tmpDir, "pkg")
+	require.NoError(t, os.MkdirAll(pkgDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agent.sock"), []byte("new"), 0644))
+
+	targetDir := filepath.Join(tmpDir, "home")
+	require.NoError(t, os.MkdirAll(targetDir, 0755))
+
+	// Create a Unix domain socket at the conflict path.
+	socketPath := filepath.Join(targetDir, "agent.sock")
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	backed, err := backupConflicts(pkgDir, targetDir)
+	require.NoError(t, err)
+	assert.Len(t, backed, 0, "socket files must not be backed up")
 }
 
 func TestBackupConflicts_SkipsMissingTargets(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Updates the `backupConflicts` function to skip socket files (and other non-regular files) instead of only skipping directories, preventing attempts to back up Unix domain sockets and similar special files.

## Why?

The previous implementation only checked `info.IsDir()` to determine whether to skip a file. This caused socket files and other special file types (named pipes, devices, etc.) to be treated as regular files and included in the backup process, which can cause errors or unexpected behavior. By checking `!info.Mode().IsRegular()` instead, we properly skip all non-regular files while still backing up actual files that need to be preserved.

## Testing

- [x] `go vet ./...` passes
- [x] Relevant tests added or updated
- Added `TestBackupConflicts_SkipsSocketFiles` to verify socket files are not backed up

## Notes for reviewer

The change is minimal and focused: replacing the directory-only check with a more comprehensive non-regular-file check. This is safer and handles edge cases like socket files that may exist at conflict paths.

https://claude.ai/code/session_01Dp7HMonM7Jc1PMcBZ4vL4P