### PR TITLE
Preserve config name when updating existing snapshot

### DIFF
--- a/internal/cli/snapshot_publish.go
+++ b/internal/cli/snapshot_publish.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/openbootdotdev/openboot/internal/auth"
+	"github.com/openbootdotdev/openboot/internal/config"
 	"github.com/openbootdotdev/openboot/internal/httputil"
 	"github.com/openbootdotdev/openboot/internal/snapshot"
 	syncpkg "github.com/openbootdotdev/openboot/internal/sync"
@@ -51,6 +52,14 @@ func publishSnapshot(ctx context.Context, snap *snapshot.Snapshot, explicitSlug 
 	if targetSlug != "" {
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintf(os.Stderr, "  Publishing to @%s/%s (updating)\n", stored.Username, targetSlug)
+		// PUT endpoint requires name; fetch the existing config to preserve it.
+		userSlug := fmt.Sprintf("%s/%s", stored.Username, targetSlug)
+		if rc, fetchErr := config.FetchRemoteConfig(userSlug, stored.Token); fetchErr == nil {
+			configName = rc.Name
+		}
+		if configName == "" {
+			configName = targetSlug
+		}
 	} else {
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "  Publishing as a new config on openboot.dev")


### PR DESCRIPTION
## What does this PR do?

When publishing a snapshot to update an existing config, fetch the remote config to preserve its name before sending the PUT request.

## Why?

The PUT endpoint requires a `name` field. When updating an existing config (rather than creating a new one), we need to preserve the existing config's name. This change fetches the remote config to get the current name, falling back to the target slug if the fetch fails or returns an empty name.

## Testing

- [ ] `go vet ./...` passes
- [ ] Tested locally with `./openboot --dry-run` when updating an existing config

## Notes for reviewer

The change gracefully handles fetch failures by falling back to using the target slug as the config name, ensuring the update can proceed even if the remote config fetch fails.

https://claude.ai/code/session_01J6FVyNhP1uSiqHbMUYHo1i