### PR TITLE
Clear screen when switching tabs in snapshot editor

### DIFF
--- a/internal/ui/snapshot_editor.go
+++ b/internal/ui/snapshot_editor.go
@@ -208,11 +208,13 @@ func (m SnapshotEditorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint
 			m.activeTab = (m.activeTab + 1) % len(m.tabs)
 			m.cursor = 0
 			m.scrollOffset = 0
+			return m, tea.ClearScreen
 
 		case key.Matches(msg, keys.ShiftTab), key.Matches(msg, keys.Left):
 			m.activeTab = (m.activeTab - 1 + len(m.tabs)) % len(m.tabs)
 			m.cursor = 0
 			m.scrollOffset = 0
+			return m, tea.ClearScreen
 
 		case key.Matches(msg, keys.Up):
 			if m.cursor > 0 {


### PR DESCRIPTION
## What does this PR do?

Add screen clearing when navigating between tabs in the snapshot editor to prevent visual artifacts.

## Why?

When switching tabs using Tab/Shift+Tab or arrow keys, the screen wasn't being cleared, which could leave remnants of the previous tab's content visible. This change ensures a clean visual transition between tabs by calling `tea.ClearScreen` after updating the active tab and resetting the cursor/scroll position.

## Testing

- [ ] `go vet ./...` passes
- [ ] Tested locally with tab navigation in snapshot editor

## Notes for reviewer

The fix is minimal and focused—it simply adds the missing screen clear command to both tab navigation code paths (forward and backward). This is consistent with proper TUI practices for tab switching.

https://claude.ai/code/session_01BRAD9BubM3QKwbm5BUFLL5