### PR TITLE
Remove empty line after tabs in snapshot editor view

### DIFF
--- a/internal/ui/snapshot_editor.go
+++ b/internal/ui/snapshot_editor.go
@@ -481,7 +481,6 @@ func (m SnapshotEditorModel) View() string { //nolint:gocyclo // renders editor 
 		}
 	}
 	lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, tabs...))
-	lines = append(lines, "")
 
 	tab := m.tabs[m.activeTab]
 	visibleItems := m.getVisibleItems()


### PR DESCRIPTION
## What does this PR do?

Removes an unnecessary empty line that was being appended after the tabs in the snapshot editor view.

## Why?

This empty line was adding unnecessary vertical spacing in the UI. Removing it provides a more compact and cleaner layout for the snapshot editor interface.

## Testing

- [ ] `go vet ./...` passes
- [ ] Tested locally (`./openboot --dry-run` or similar)

## Notes for reviewer

This is a minor UI spacing adjustment with no functional impact on the editor's behavior.

https://claude.ai/code/session_01A8CMu3PkMS8ezqjhXGAxxh