### PR TITLE
fix(ui): skip invalid MacOSPref entries (empty domain/key) in snapshot editor

### DIFF
--- a/internal/ui/snapshot_editor.go
+++ b/internal/ui/snapshot_editor.go
@@ -114,14 +114,17 @@ func NewSnapshotEditor(snap *snapshot.Snapshot) SnapshotEditorModel {
 	}
 	tabs[3] = editorTab{name: "Taps", icon: "🔌", items: tapItems, itemType: editorItemTap}
 
-	prefItems := make([]editorItem, len(snap.MacOSPrefs))
-	for i, p := range snap.MacOSPrefs {
-		prefItems[i] = editorItem{
+	var prefItems []editorItem
+	for _, p := range snap.MacOSPrefs {
+		if p.Domain == "" || p.Key == "" {
+			continue
+		}
+		prefItems = append(prefItems, editorItem{
 			name:        fmt.Sprintf("%s.%s", p.Domain, p.Key),
 			description: fmt.Sprintf("= %s (%s)", p.Value, p.Desc),
 			selected:    true,
 			itemType:    editorItemMacOSPref,
-		}
+		})
 	}
 	tabs[4] = editorTab{name: "macOS Prefs", icon: "⚙️ ", items: prefItems, itemType: editorItemMacOSPref}
 

--- a/internal/ui/snapshot_editor_test.go
+++ b/internal/ui/snapshot_editor_test.go
@@ -71,8 +71,8 @@ func TestNewSnapshotEditorItems(t *testing.T) {
 func TestNewSnapshotEditorSkipsInvalidMacOSPrefs(t *testing.T) {
 	snap := makeTestSnapshot()
 	snap.MacOSPrefs = append(snap.MacOSPrefs,
-		snapshot.MacOSPref{Domain: "cirruslabs/cli", Key: ""},   // tap misclassified as pref
-		snapshot.MacOSPref{Domain: "", Key: "SomeKey"},           // empty domain
+		snapshot.MacOSPref{Domain: "cirruslabs/cli", Key: ""},                      // tap misclassified as pref
+		snapshot.MacOSPref{Domain: "", Key: "SomeKey"},                             // empty domain
 		snapshot.MacOSPref{Domain: "com.apple.dock", Key: "tilesize", Value: "48"}, // valid
 	)
 	m := NewSnapshotEditor(snap)

--- a/internal/ui/snapshot_editor_test.go
+++ b/internal/ui/snapshot_editor_test.go
@@ -68,6 +68,25 @@ func TestNewSnapshotEditorItems(t *testing.T) {
 	assert.Equal(t, "homebrew/core", m.tabs[3].items[0].name)
 }
 
+func TestNewSnapshotEditorSkipsInvalidMacOSPrefs(t *testing.T) {
+	snap := makeTestSnapshot()
+	snap.MacOSPrefs = append(snap.MacOSPrefs,
+		snapshot.MacOSPref{Domain: "cirruslabs/cli", Key: ""},   // tap misclassified as pref
+		snapshot.MacOSPref{Domain: "", Key: "SomeKey"},           // empty domain
+		snapshot.MacOSPref{Domain: "com.apple.dock", Key: "tilesize", Value: "48"}, // valid
+	)
+	m := NewSnapshotEditor(snap)
+
+	// Only valid prefs (non-empty domain AND key) should appear in the macOS Prefs tab.
+	prefTab := m.tabs[4]
+	for _, item := range prefTab.items {
+		assert.NotEmpty(t, item.name, "pref item name must not be empty")
+		assert.Contains(t, item.name, ".", "pref item name must contain a dot separator")
+	}
+	// 2 from makeTestSnapshot + 1 valid new pref = 3
+	assert.Equal(t, 3, len(prefTab.items))
+}
+
 func TestNewSnapshotEditorAllItemsSelected(t *testing.T) {
 	snap := makeTestSnapshot()
 	m := NewSnapshotEditor(snap)


### PR DESCRIPTION
## Summary

- A corrupted or old-format snapshot file can contain a `MacOSPref` entry with an empty `Key` (e.g. `Domain="cirruslabs/cli"`, `Key=""`), which caused that entry to appear in the macOS Prefs tab as `"cirruslabs/cli."` — visually indistinguishable from just `"cirruslabs/cli"` because the trailing dot is tiny and the `"=  ()"` description renders in faint gray.
- Every valid macOS preference requires both a non-empty `Domain` **and** a non-empty `Key`. Entries missing either are now skipped when building the macOS Prefs tab in `NewSnapshotEditor`.
- The tap itself (`cirruslabs/cli`) is already correctly shown in the Taps tab from `snap.Packages.Taps`; only the phantom `MacOSPref` entry is dropped.

## What changed

- `internal/ui/snapshot_editor.go`: Changed pref-items loop from pre-allocated slice to append-with-guard, skipping any `MacOSPref` where `Domain == ""` or `Key == ""`.
- `internal/ui/snapshot_editor_test.go`: Added `TestNewSnapshotEditorSkipsInvalidMacOSPrefs` to cover tap-misclassified-as-pref entries, empty-domain entries, and valid new prefs.

## Test plan

- [ ] `make test-unit` passes
- [ ] Run `openboot snapshot capture` and confirm no items appear in the macOS Prefs tab that look like Homebrew taps
- [ ] Import a snapshot file containing a `macos_prefs` entry with empty `key` and confirm it is silently dropped from the macOS Prefs tab