### PR TITLE
fix(ui): use tabStyle for inactive tabs to resolve unused var lint error

### DIFF
--- a/internal/ui/selector_view.go
+++ b/internal/ui/selector_view.go
@@ -86,7 +86,6 @@ func (m SelectorModel) renderTabBar() string {
 	totalTabs := len(m.categories)
 
 	arrowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#555"))
-	neighborStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#666"))
 	sepStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#444"))
 	posStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#555"))
 
@@ -131,7 +130,7 @@ func (m SelectorModel) renderTabBar() string {
 	for remaining > 0 && (li >= 0 || ri < totalTabs) {
 		added := false
 		if li >= 0 {
-			rendered := neighborStyle.Render(m.categories[li].Name)
+			rendered := tabStyle.Render(m.categories[li].Name)
 			w := lipgloss.Width(rendered) + sepW
 			if w <= remaining {
 				leftNeighbors = append([]string{rendered}, leftNeighbors...)
@@ -143,7 +142,7 @@ func (m SelectorModel) renderTabBar() string {
 			}
 		}
 		if ri < totalTabs {
-			rendered := neighborStyle.Render(m.categories[ri].Name)
+			rendered := tabStyle.Render(m.categories[ri].Name)
 			w := lipgloss.Width(rendered) + sepW
 			if w <= remaining {
 				rightNeighbors = append(rightNeighbors, rendered)


### PR DESCRIPTION
## Summary
- `tabStyle` was declared in `selector_view.go` but never used, causing `golangci-lint` to fail
- `renderTabBar()` was creating an inline `neighborStyle` (same `#666` colour) instead of using the package-level var
- Replace the inline local with `tabStyle` to remove the duplication and satisfy the linter

## Test plan
- [ ] `go vet ./internal/ui/...` passes
- [ ] Lint CI job passes