### PR TITLE
fix(config): split domainKeyRe into separate domain and key regexes

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -13,9 +13,11 @@ const (
 )
 
 var (
-	pkgNameRe   = regexp.MustCompile(`^[a-zA-Z0-9@/_.-]+$`)
-	tapNameRe   = regexp.MustCompile(`^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$`)
-	domainKeyRe = regexp.MustCompile(`^[a-zA-Z0-9 ._-]+$`)
+	pkgNameRe = regexp.MustCompile(`^[a-zA-Z0-9@/_.-]+$`)
+	tapNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$`)
+	// macOS preference domains never contain spaces; keys may (e.g. "NSStatusItem Visible Sound").
+	domainRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	keyRe    = regexp.MustCompile(`^[a-zA-Z0-9 ._-]+$`)
 
 	// dotfilesPathRe validates the path component: one or more segments of
 	// alphanumeric, dash, underscore, or dot characters separated by slashes.
@@ -126,10 +128,10 @@ func validateMacOSPrefs(rc *RemoteConfig) error {
 		if strings.HasPrefix(mp.Key, "-") {
 			return fmt.Errorf("invalid macos_prefs key: %q must not start with '-'", mp.Key)
 		}
-		if !domainKeyRe.MatchString(mp.Domain) {
+		if !domainRe.MatchString(mp.Domain) {
 			return fmt.Errorf("macos preference domain %q contains invalid characters", mp.Domain)
 		}
-		if !domainKeyRe.MatchString(mp.Key) {
+		if !keyRe.MatchString(mp.Key) {
 			return fmt.Errorf("macos preference key %q contains invalid characters", mp.Key)
 		}
 	}

--- a/internal/config/validate_extra_test.go
+++ b/internal/config/validate_extra_test.go
@@ -62,7 +62,7 @@ func TestValidateMacOSPrefs_KeyStartsWithDash(t *testing.T) {
 func TestValidateMacOSPrefs_InvalidDomainCharacters(t *testing.T) {
 	rc := &RemoteConfig{
 		MacOSPrefs: []RemoteMacOSPref{
-			{Domain: "com.apple;dock", Key: "autohide", Type: "bool"},
+			{Domain: "com.apple dock", Key: "autohide", Type: "bool"},
 		},
 	}
 	err := validateMacOSPrefs(rc)
@@ -128,7 +128,7 @@ func TestValidateMacOSPrefs_KeyWithSpaces(t *testing.T) {
 }
 
 func TestValidateMacOSPrefs_DomainWithSpecialValidChars(t *testing.T) {
-	// Domain and key regex: [a-zA-Z0-9 ._-]+
+	// domainRe: [a-zA-Z0-9._-]+  keyRe: [a-zA-Z0-9 ._-]+
 	validDomains := []string{
 		"com.apple.dock",
 		"NSGlobalDomain",


### PR DESCRIPTION
## Summary

- Splits the shared `domainKeyRe` into `domainRe` (no spaces) and `keyRe` (spaces allowed)
- Restores the domain-with-space test case that was inadvertently dropped in #53

## Context

#53 correctly allowed spaces in macOS preference *keys* (e.g. `NSStatusItem Visible Sound`), but because the same regex was used for both domains and keys, spaces became valid in domains too (e.g. `com.apple dock`). This follow-up fixes the over-permissiveness without changing any user-facing behaviour.

## Test plan

- [ ] `go test -run TestValidateMacOSPrefs ./internal/config/...` passes
- [ ] `TestValidateMacOSPrefs_InvalidDomainCharacters` now uses a space in the domain (correctly rejected)
- [ ] `TestValidateMacOSPrefs_KeyWithSpaces` still passes (spaces in keys still allowed)