### PR TITLE
fix(security): bump go directive 1.24.0 → 1.25.10 to clear 8 stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openbootdotdev/openboot
 
-go 1.24.0
+go 1.25.10
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
## Summary

Single-line bump of `go` directive in `go.mod` from `1.24.0` to `1.25.10`. Clears the 8 stdlib advisories that the new `govulncheck` drift sensor (added in #55) flagged on `main`.

This is the harness PR's first useful follow-up: a drift sensor surfaced a real, reachable security issue, and this PR encodes the fix.

## Advisories cleared

| ID | Package (1.24) | Fixed in |
|---|---|---|
| GO-2026-4971 | `net` | 1.25.10 |
| GO-2026-4947 | `crypto/x509` | 1.25.9 |
| GO-2026-4946 | `crypto/x509` | 1.25.9 |
| GO-2026-4918 | `net/http` | 1.25.10 |
| GO-2026-4870 | `crypto/tls` | 1.25.9 |
| GO-2026-4602 | `os` | 1.25.8 |
| GO-2026-4601 | `net/url` | 1.25.8 |
| GO-2026-4340 | `crypto/tls` | 1.24.12 (covered) |

All flagged by `govulncheck`'s reachability analysis — i.e. openboot's call graph genuinely reaches those stdlib paths.

## Scope

- `go.mod`: `go 1.24.0` → `go 1.25.10`. **One line.**
- `go.sum`: unchanged (no module updates).
- No source changes. No workflow changes — CI's `setup-go@v5` reads `go-version-file: "go.mod"` and will install 1.25.10 automatically.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — 20/20 packages pass
- [ ] CI: lint, unit, integration, contract, curl|bash smoke, old-cli compat
- [ ] CI: `govulncheck` drift job should now report **no advisories** (the original signal closes)

## Risk / rollback

- **Risk**: very low. Patch-version bump; no API changes between 1.24 and 1.25 that affect this codebase. Build / vet / tests all clean locally.
- **Rollback**: one-line revert of `go.mod`.
- **Compat**: macOS-only project, runs from `make build` against the toolchain in `go.mod`. Users running `go install` need Go ≥ 1.25.10; the curl\|bash installer ships a prebuilt binary so end users are unaffected.

## Relationship to #55

#55 (harness engineering) added `govulncheck` as a `continue-on-error` drift sensor. On its first run on `main` it surfaced these 8 CVEs. This PR is the steering-loop response: sensor fires → human encodes fix. After merge, the same sensor on #55's branch will go green.