### PR TITLE
docs(merge-policy): codify required CI checks for main

### DIFF
--- a/docs/MERGE_POLICY.md
+++ b/docs/MERGE_POLICY.md
@@ -1,0 +1,77 @@
+# Merge policy
+
+This document codifies which CI checks must be green before a PR can be
+merged into `main`. It is the human-readable counterpart to the GitHub
+branch protection rules configured at:
+
+> Settings → Branches → Branch protection rules → `main`
+
+If the two ever drift, **GitHub is authoritative** — file a PR against
+this doc to bring it back in sync.
+
+## Required checks on `main`
+
+A PR cannot be merged unless every one of these checks reports success on
+the merge commit's tip:
+
+| Check | Workflow | Why required |
+|---|---|---|
+| `lint` | Test | Catches gofmt / gosec / staticcheck issues that block release builds. |
+| `unit (L1)` | Test | The fast Go unit + contract suite. Includes `internal/archtest` fitness rules. |
+| `integration (L2)` | Test | Real `brew` / `git` / `npm` in temp dirs. Catches integration drift the unit suite can't. |
+| `contract schema (L3)` | Test | Validates remote-config / snapshot JSON against the `openboot-contract` schemas. Breaking the contract breaks live users. |
+| `curl\|bash smoke` | Test | Confirms `scripts/install.sh` still bootstraps the CLI against a mock server. |
+| `old-cli compat` | Test | Runs the **previous** release binary against the **current** mock server. Catches server-side changes that would break already-shipped CLIs in the field. |
+
+## Not required (and why)
+
+| Check | Status | Reason |
+|---|---|---|
+| `macos e2e (L5)` | runs only on tag pushes / manual dispatch | Slow + destructive; runs at release time, not per PR. |
+| Harness drift sensors (`govulncheck`, `deadcode`, `mod-tidy diff`, `archtest stale baseline`) | `continue-on-error: true` | Informational by design. Failures surface as annotations and, on `main`, open tracking issues via `drift-to-issue.yml`. |
+| `codecov/patch` | informational | Coverage threshold is a guideline, not a gate. Hard coverage gates push toward test-shaped code without raising actual quality. |
+
+## Operating principles
+
+- **Floor, not ceiling.** Branch protection enforces the floor every PR
+  must clear. Human review still raises the ceiling — *form*-level checks
+  cannot replace a reviewer reading the diff for behaviour or design.
+- **No admin bypass for routine work.** Admins can override in genuine
+  emergencies but should not make a habit of it. Bypass usage is visible
+  in the GitHub audit log.
+- **Required ≠ blocking forever.** If a check is broken upstream (e.g.
+  GitHub Actions outage), document the bypass in the merge PR description.
+- **New checks are NOT auto-required.** Adding a workflow job does not
+  add it to this list. Promote a check to required by editing this doc
+  and updating branch protection in the same PR.
+
+## Why these six
+
+Each required check covers a class of regression that has shipped to
+users in past commits:
+
+- `lint` blocks PRs that fail `golangci-lint` (would block release build).
+- `unit (L1)` is the cheapest, broadest behaviour check.
+- `integration (L2)` catches real-subprocess bugs (brew flags changing,
+  `git` exit codes shifting between macOS versions).
+- `contract schema (L3)` is the contract with the openboot.dev API — any
+  drift breaks every CLI in the field.
+- `curl|bash smoke` covers the **primary install path** for new users.
+  Breaking this is a silent acquisition disaster.
+- `old-cli compat` is the contract with *already-installed* CLIs.
+  Server-side changes that break this strand users on the version they
+  have until they upgrade — which they may never do.
+
+## How to change this policy
+
+1. Open a PR that edits this file with the proposed change.
+2. In the same PR, update branch protection via the GitHub UI **or**
+   include the `gh api` command in the PR description so the reviewer can
+   reproduce it. Example:
+
+   ```bash
+   gh api -X PUT repos/openbootdotdev/openboot/branches/main/protection \
+     --input docs/_protection.json
+   ```
+
+3. After merge, verify with `gh api repos/openbootdotdev/openboot/branches/main/protection`.


### PR DESCRIPTION
## Summary

Adds `docs/MERGE_POLICY.md` — the human-readable counterpart to GitHub's branch protection rules on `main`. Lists 6 required checks, the ones intentionally NOT required, and the process for changing the policy.

This is the **floor-not-ceiling** piece of harness engineering: the harness enforces a baseline every PR must clear, while human review still raises the ceiling.

## Required checks (per this PR)

- `lint`
- `unit (L1)`
- `integration (L2)`
- `contract schema (L3)`
- `curl|bash smoke`
- `old-cli compat`

## NOT required (with reasons in the doc)

- `macos e2e (L5)` — only runs on tags
- Harness drift sensors — informational by design
- `codecov/patch` — coverage is a guideline, not a gate

## Activating the policy

This PR is the doc only. The actual branch protection is configured out-of-band via a single `gh api` call against the live repo. After merge:

```bash
gh api -X PUT repos/openbootdotdev/openboot/branches/main/protection \
  -H "Accept: application/vnd.github+json" \
  -f required_status_checks[strict]=true \
  -f 'required_status_checks[contexts][]=lint' \
  -f 'required_status_checks[contexts][]=unit (L1)' \
  -f 'required_status_checks[contexts][]=integration (L2)' \
  -f 'required_status_checks[contexts][]=contract schema (L3)' \
  -f 'required_status_checks[contexts][]=curl|bash smoke' \
  -f 'required_status_checks[contexts][]=old-cli compat' \
  -F enforce_admins=false \
  -F required_pull_request_reviews= \
  -F restrictions=
```

Reproduce + verify after applying:

```bash
gh api repos/openbootdotdev/openboot/branches/main/protection
```

## Risk / rollback

- **Risk**: low for the doc PR itself.
- **Risk of activating protection**: medium — once required checks are enforced, *no PR can merge until all 6 pass*. If any check is flaky, that's a problem. Mitigation: all 6 are currently green on `main`.
- **Rollback**: `gh api -X DELETE repos/openbootdotdev/openboot/branches/main/protection` removes all protection (one command, reversible).
- **Admin bypass**: `enforce_admins=false` means repo admins can still merge in emergencies without satisfying the checks. Audit log captures every bypass.

## Test plan

- [x] Doc renders correctly (markdown preview)
- [ ] After merge: apply branch protection via the `gh api` command above
- [ ] Verify with `gh api repos/openbootdotdev/openboot/branches/main/protection`
- [ ] Open a test PR with a deliberate `lint` break to confirm merge button is disabled