### PR TITLE
feat(macos): manage menu bar / Control Center icons

### DIFF
--- a/internal/macos/categories.go
+++ b/internal/macos/categories.go
@@ -105,6 +105,21 @@ var DefaultCategories = []PrefCategory{
 		},
 	},
 	{
+		Name: "Menu Bar",
+		Icon: "🎛",
+		Prefs: []Preference{
+			{"com.apple.controlcenter", "NSStatusItem Visible Sound", "bool", "true", "Show Sound in menu bar"},
+			{"com.apple.controlcenter", "NSStatusItem Visible Bluetooth", "bool", "true", "Show Bluetooth in menu bar"},
+			{"com.apple.controlcenter", "NSStatusItem Visible WiFi", "bool", "true", "Show Wi-Fi in menu bar"},
+			{"com.apple.controlcenter", "NSStatusItem Visible Battery", "bool", "true", "Show Battery in menu bar"},
+			{"com.apple.controlcenter", "NSStatusItem Visible AirDrop", "bool", "false", "Hide AirDrop from menu bar"},
+			{"com.apple.controlcenter", "NSStatusItem Visible Display", "bool", "false", "Hide Display from menu bar"},
+			{"com.apple.controlcenter", "NSStatusItem Visible FocusModes", "bool", "false", "Hide Focus Modes from menu bar"},
+			{"com.apple.controlcenter", "NSStatusItem Visible NowPlaying", "bool", "false", "Hide Now Playing from menu bar"},
+			{"com.apple.controlcenter", "NSStatusItem Visible ScreenMirroring", "bool", "false", "Hide Screen Mirroring from menu bar"},
+		},
+	},
+	{
 		Name: "Security",
 		Icon: "🔒",
 		Prefs: []Preference{

--- a/internal/macos/macos.go
+++ b/internal/macos/macos.go
@@ -128,7 +128,7 @@ func CreateScreenshotsDir(dryRun bool) error {
 }
 
 func RestartAffectedApps(dryRun bool) error {
-	apps := []string{"Finder", "Dock", "SystemUIServer"}
+	apps := []string{"Finder", "Dock", "SystemUIServer", "ControlCenter"}
 
 	for _, app := range apps {
 		if dryRun {


### PR DESCRIPTION
## Summary
- New "Menu Bar" preference category in `internal/macos/categories.go` covering 9 common Control Center modules: Sound, Bluetooth, Wi-Fi, Battery, AirDrop, Display, FocusModes, NowPlaying, ScreenMirroring.
- Each entry writes `NSStatusItem Visible <Module>` (bool) under `com.apple.controlcenter`. Capture and restore flow through `DefaultPreferences` automatically.
- Add `ControlCenter` to `RestartAffectedApps` in `internal/macos/macos.go` — writes to `com.apple.controlcenter` don't take effect until that process is killed.

## Why
Menu bar icon visibility wasn't managed at all. `openboot install` couldn't enforce it and `openboot snapshot --publish` couldn't preserve it across machines.

## Defaults
Defaults err toward a familiar clean menu bar:
- **Shown:** Sound, Bluetooth, Wi-Fi, Battery
- **Hidden:** AirDrop, Display, FocusModes, NowPlaying, ScreenMirroring

Snapshot capture uses each machine's current value, so the catalog defaults only matter for the fresh-install / opt-in path.

## Notes
- Scope intentionally limited to the bool visibility keys. The companion `com.apple.controlcenter` integer module keys (mode: in-CC-only / always-in-menu-bar / show-when-active) are *not* added — they have inconsistent value semantics per module and macOS version. Round-trip works for "is icon visible" which is what almost everyone configures.
- Module names use the Apple internal identifiers (`WiFi`, `FocusModes`, `NowPlaying`, `ScreenMirroring`) which is what the underlying defaults keys require.

## Test plan
- [x] `go test ./internal/macos/...` — passes
- [x] `go test ./internal/snapshot/...` — passes
- [ ] Manual: run `openboot install` selecting Menu Bar prefs → verify visibility in menu bar after `killall ControlCenter`
- [ ] Manual: `openboot snapshot` on a machine with custom menu bar → confirm `NSStatusItem Visible *` entries present in snapshot JSON
- [ ] Manual: restore that snapshot on a fresh machine → confirm same icons visible/hidden