### PR TITLE
chore(harness): remove session-start stale-branch sensor (dead code)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,33 +1,12 @@
 #!/bin/bash
-set -uo pipefail
+set -euo pipefail
 
-cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
-
-# --- Stale-branch sensor (always runs, cheap, ~1s with --quiet fetch) ---
-# After `ship-pr` flow / auto-merge with --delete-branch, the remote branch
-# is gone but the local branch lingers. Detect and suggest cleanup so the
-# next session doesn't start on an orphan branch.
-if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
-  current=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
-  if [ -n "$current" ] && [ "$current" != "main" ]; then
-    # Prune local refs for deleted remote branches. Network call, but cheap
-    # against an already-cloned repo; silenced so we don't spam the session.
-    git fetch --prune --quiet origin 2>/dev/null || true
-    track=$(git rev-parse --symbolic-full-name --abbrev-ref "${current}@{upstream}" 2>/dev/null || true)
-    if [ -n "$track" ] && ! git show-ref --verify --quiet "refs/remotes/${track}"; then
-      echo "[openboot session-start] Branch '$current' tracks '$track' — gone on remote (likely merged)." >&2
-      echo "  Cleanup: git checkout main && git pull && git branch -d $current" >&2
-    fi
-  fi
-fi
-
-# --- Cache warming (Claude Code on the web only) ---
-# Local users don't need this — their caches stay warm across sessions.
+# Only run in Claude Code on the web; skip on local machines.
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-set -e
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 echo "[openboot session-start] Go version: $(go version)"
 

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -169,9 +169,9 @@ git branch -d "$(git symbolic-ref --quiet --short @{-1} 2>/dev/null)"
 (`@{-1}` refers to the previously checked-out branch — the one we just
 merged.)
 
-If the user closes the session before reaching Step 8, the
-[`session-start.sh`](../../hooks/session-start.sh) stale-branch sensor
-catches it on the next session and prints the same cleanup hint.
+This step is part of the loop, not optional. Because merges are
+synchronous now (no `--auto`), there is no scenario where a feature
+branch should be left checked out after a successful merge.
 
 ## What NOT to do
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -55,7 +55,6 @@ Three regulation categories:
 | Feedfwd. | Agent conventions | every AI turn | `CLAUDE.md`, `AGENTS.md` |
 | Feedfwd. | Skills | model-loaded | `.claude/skills/*` |
 | Feedfwd. | Session-start hook (warm caches, fetch deps) | every Claude session | `.claude/hooks/session-start.sh` |
-| Feedback (agent) | Stale-branch sensor (suggests cleanup when current branch's upstream is gone) | every Claude session | `.claude/hooks/session-start.sh` |
 | Feedfwd. | `ship-pr` skill — canonical PR flow (push → CI → review → triage: self-fix / escalate / merge directly when clean → cleanup; **no `--auto`**, **no "do you want me to merge?" when clean**) | model-loaded | `.claude/skills/ship-pr/SKILL.md` |
 | Feedback (agent) | `go vet` on edited package | after every Edit/Write/MultiEdit | `.claude/hooks/post-tool-use.sh` |
 | Feedback (agent) | `go vet ./...` + archtest | end of every Claude turn (if .go dirty) | `.claude/hooks/stop.sh` |
@@ -95,6 +94,14 @@ it survives doc rot.
 - **No retroactive refactors triggered by new archtest rules.** New rules
   baseline existing code so green builds stay green. Cleanup is a separate
   decision from rule introduction.
+- **No session-start stale-branch sensor.** A previous iteration of the
+  `ship-pr` skill used `gh pr merge --auto`, so the merge could happen
+  asynchronously after the Claude session ended — leaving a feature
+  branch checked out next time. The sensor existed to nag the user to
+  clean it up. Once the skill dropped `--auto` and made cleanup part of
+  the in-session loop (Step 8), the sensor became dead code and was
+  removed. If `--auto` ever comes back, the sensor needs to come back
+  with it.
 
 ## How agents should think about this file
 


### PR DESCRIPTION
## Summary

The session-start stale-branch sensor (added in #63) was introduced when `ship-pr` used `gh pr merge --auto`. With auto-merge, merges happened asynchronously after the Claude session ended, so a feature branch could linger checked out into the next session — the sensor nagged the user to clean it up.

#64 dropped `--auto`. Merges are now synchronous and cleanup is Step 8 of the in-session loop, which always runs before the session ends on a shipped PR. The sensor's trigger condition can no longer occur in normal flow, so it's dead code paying for a per-session `git fetch`.

Changes:

- **`.claude/hooks/session-start.sh`** — restored to pre-#63 shape (cache warming only on Claude Code on the web).
- **`.claude/skills/ship-pr/SKILL.md`** — dropped the "if the user closes the session before reaching Step 8 the sensor will catch it" fallback paragraph; cleanup is now described as part of the loop, not optional.
- **`docs/HARNESS.md`** — removed the sensor row from the controls table; added an entry under "What's intentionally NOT in the harness" explaining the removal, so a future agent doesn't re-add the sensor without also re-adding `--auto`.

## Test plan

- [x] `bash -n .claude/hooks/session-start.sh` (syntax)
- [ ] CI green (will validate before merge per the new ship-pr flow).