### PR TITLE
feat(macos): capture "Click wallpaper to show desktop" preference

### DIFF
--- a/internal/macos/categories.go
+++ b/internal/macos/categories.go
@@ -135,6 +135,15 @@ var DefaultCategories = []PrefCategory{
 			{"com.apple.screensaver", "askForPasswordDelay", "int", "0", "No delay before password required"},
 		},
 	},
+	{
+		Name: "Desktop & Stage Manager",
+		Icon: "🪟",
+		Prefs: []Preference{
+			// false → wallpaper click hides windows only while Stage Manager is active (macOS Sonoma+ default).
+			// true  → wallpaper click always reveals desktop (pre-Sonoma behaviour).
+			{"com.apple.WindowManager", "EnableStandardClickToShowDesktop", "bool", "false", "Click wallpaper to show desktop only in Stage Manager"},
+		},
+	},
 }
 
 // AllPrefsSelected returns a map with all default preferences set to true.


### PR DESCRIPTION
## Summary

Adds a "Desktop & Stage Manager" category covering `com.apple.WindowManager` `EnableStandardClickToShowDesktop`. Previously this key was outside the `DefaultPreferences` catalog, so `openboot snapshot` silently dropped it (capture skips any pref not in the catalog) and `openboot install` couldn't write it.

User reported the gap with a screenshot of the snapshot UI showing the category at 1/1 with the stored value, indicating the web side knows about the key but the CLI snapshot was never capturing it.

Default is `false` to match macOS Sonoma+'s built-in default (wallpaper click only hides windows while Stage Manager is active). Set to `true` for the pre-Sonoma "always reveal desktop" behaviour.

Follows the same pattern as #58 (hot corners) and the menu bar / Control Center icons PR — single-file change to `internal/macos/categories.go`, picked up automatically by `DefaultPreferences` → snapshot capture + `Configure` → restore.

## Test plan

- [x] `go vet ./internal/macos/... ./internal/snapshot/... ./internal/archtest/...`
- [x] `go test ./internal/macos/... ./internal/archtest/...` (L1 incl. `TestDefaultPreferences_DerivedFromCategories` and `TestDefaultPreferences_NoDuplicateKeys`)
- [ ] CI green (will validate before merge).