### PR TITLE
chore(harness): merge L2 integration tests into L1

### DIFF
--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -52,9 +52,9 @@ For each changed file under `internal/` or `cmd/`:
 
 For each non-trivial change:
 
-- **Pure logic** → must have an L1 test. If missing, request it.
-- **Subprocess interaction** → fake via Runner in L1 OR add L2 with
-  `//go:build integration`.
+- **Pure logic** → must have an L1 test in `internal/<pkg>/`. If missing, request it.
+- **Subprocess interaction** → fake via Runner in `internal/<pkg>/` OR add a
+  real-subprocess test under `test/integration/` (still L1, no build tag).
 - **CLI flag parsing** → table-driven L1 test.
 - **Destructive op** → must run cleanly under `--dry-run` in a test.
 
@@ -67,7 +67,7 @@ unmentioned.
 | Check | Why it matters |
 |---|---|
 | Does the change break the curl\|bash install path? | `scripts/install.sh` is the primary install vector. The smoke test CI job covers this — make sure it still passes. |
-| Does the change alter the contract schema (config / snapshot JSON)? | If yes, the schema needs updating in `openboot-contract` repo and bumping. Otherwise the L3 contract job will fail. |
+| Does the change alter the contract schema (config / snapshot JSON)? | If yes, the schema needs updating in `openboot-contract` repo and bumping. Otherwise the L2 contract job will fail. |
 | Does the change add or change a CLI flag? | Confirm `--help` output is updated, and old-cli compat job still passes (previous release × new mock server). |
 | Does the change touch `data/presets.yaml`? | Three presets must still parse and resolve. |
 | Does the change touch `~/.openboot/*` file format? | Confirm backward compat with old files (snapshot, auth, state) or write a migration. |

--- a/.claude/skills/bootstrap-feature/SKILL.md
+++ b/.claude/skills/bootstrap-feature/SKILL.md
@@ -78,25 +78,26 @@ type fakeRunner struct { ... }
 func (f *fakeRunner) Output(args ...string) ([]byte, error) { ... }
 ```
 
-This is the pattern that lets L1 stay at ~15s without touching real brew/git/npm.
+This is the pattern that lets the fake-runner half of L1 stay fast and hermetic.
 
 ## Step 4 — Test placement
 
 | Scope | Tier | Build tag | Where |
 |---|---|---|---|
 | Pure logic + fakes | L1 | none | `<pkg>/<feature>_test.go` |
-| Real subprocess in temp dir | L2 | `integration` | `<pkg>/<feature>_integration_test.go` |
-| Compiled binary, no installs | L4 | `e2e` | `test/e2e/...` |
-| Real installs on macOS | L5/L6 | `e2e,vm,destructive` | `test/e2e/...` |
+| Real subprocess in temp dir | L1 | none | `test/integration/<feature>_integration_test.go` |
+| Compiled binary, no installs | L3 | `e2e` | `test/e2e/...` |
+| Real installs on macOS | L4/L5 | `e2e,vm,destructive` | `test/e2e/...` |
 
-Default to L1 unless the thing you're testing only exists when a real
-brew/git/npm is on the path.
+Default to faked-runner L1 unless the thing you're testing only exists when a real
+brew/git/npm is on the path — then add an integration test under `test/integration/`
+(no build tag; it runs as part of L1).
 
 ## Step 5 — Verify before committing
 
 ```bash
 go vet ./...
-make test-unit                  # ~15s, includes archtest
+make test-unit                  # ~75s, includes archtest + integration
 ```
 
 If archtest fails with a new violation, fix the code rather than

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -80,8 +80,8 @@ This blocks until every check finishes. Typical wall time is 3–10 min
 depending on which jobs run. The required checks per
 [docs/MERGE_POLICY.md](../../../docs/MERGE_POLICY.md):
 
-- `lint`, `unit (L1)`, `integration (L2)`, `contract schema (L3)`,
-  `curl|bash smoke`, `old-cli compat`
+- `lint`, `unit (L1)`, `contract schema (L2)`, `curl|bash smoke`,
+  `old-cli compat`
 
 If any required check fails:
 - **Stop. Do not proceed to review or merge.**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,6 @@ jobs:
       - name: Unit tests
         run: make test-unit
 
-      - name: Integration tests
-        run: make test-integration
-
       - name: Destructive tests
         run: make test-destructive
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,27 +74,8 @@ jobs:
             coverage.html
           retention-days: 7
 
-  integration:
-    name: integration (L2)
-    runs-on: macos-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: "go.mod"
-
-      - name: Run integration tests
-        run: make test-integration
-
-      - name: Run destructive tests
-        if: ${{ inputs.run_destructive == true }}
-        run: make test-destructive
-
   contract:
-    name: contract schema (L3)
+    name: contract schema (L2)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -159,7 +140,7 @@ jobs:
         run: kill $(cat /tmp/mock-pid) 2>/dev/null || true
 
   macos-e2e:
-    name: macos e2e (L5)
+    name: macos e2e (L4)
     runs-on: macos-latest
     # Only on release tags or manual dispatch — these are slow and destructive.
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
@@ -175,6 +156,22 @@ jobs:
 
       - name: Run macOS E2E (release tier)
         run: make test-vm-release
+
+  destructive:
+    name: destructive (L5)
+    runs-on: macos-latest
+    if: ${{ inputs.run_destructive == true }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Run destructive tests
+        run: make test-destructive
 
   cli-compat:
     name: old-cli compat

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ human, you probably want [README.md](README.md) or [CONTRIBUTING.md](CONTRIBUTIN
 
 - **[CLAUDE.md](CLAUDE.md)** — project conventions and where-to-look table.
   Treat this as authoritative; this file is a summary index for agents.
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** — test layering L1–L6, Runner
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — test layering L1–L5, Runner
   interface, hook setup.
 - **[docs/HARNESS.md](docs/HARNESS.md)** — the steering meta-doc: when a
   class of issue recurs, which file do you edit to prevent it next time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ OpenBoot is a **macOS-only** Go 1.24 CLI that automates dev-environment setup: H
 Entry point: `cmd/openboot/main.go` → `internal/cli.Execute()`.
 Core flow: `openboot install` runs a 7-step wizard in `internal/installer/installer.go`.
 
-For full contribution guide (test layering L1–L6, Runner interface, hook setup) see @CONTRIBUTING.md.
+For full contribution guide (test layering L1–L5, Runner interface, hook setup) see @CONTRIBUTING.md.
 For AI agents: @AGENTS.md indexes invariants enforced by `internal/archtest`; @docs/HARNESS.md is the steering meta-doc for where to encode new rules.
 
 ## Commands
@@ -18,11 +18,10 @@ make build
 make build-release VERSION=0.25.0    # optimized + UPX
 
 # Test — full tier table in CONTRIBUTING.md
-make test-unit                       # L1 (~15s) — pre-push hook
-make test-integration                # L2 (~75s) — real brew/git/npm in temp dirs
-make test-e2e                        # L4 compiled binary
-make test-vm-release                 # L5 destructive macOS (~20m) — before tagging
-make test-destructive                # L6 — actually installs
+make test-unit                       # L1 (~75s) — unit + integration + contract; pre-push hook
+make test-e2e                        # L3 compiled binary
+make test-vm-release                 # L4 destructive macOS (~20m) — before tagging
+make test-destructive                # L5 — actually installs
 make test-coverage                   # coverage.out + coverage.html
 
 # Single test
@@ -59,7 +58,7 @@ internal/
   system/            # RunCommand / RunCommandSilent, arch, git config
   ui/                # bubbletea Model pattern, lipgloss styling
   updater/           # Auto-update: check GitHub → download → replace
-test/{integration,e2e}/   # //go:build integration | e2e (+ vm, destructive, smoke)
+test/{integration,e2e}/   # integration runs as part of L1; e2e gated by build tags (e2e, vm, destructive, smoke)
 testutil/            # shared helpers + MacHost (destructive E2E on real macOS)
 scripts/
   install.sh         # curl|bash installer
@@ -81,7 +80,7 @@ scripts/
 | Change publish flow | `internal/cli/snapshot_publish.go` (`publishSnapshot`) | Slug resolution |
 | Source resolution (install) | `internal/cli/install.go` (`resolvePositionalArg`) | file / user-slug / preset / alias detection |
 | HTTP with retry | `internal/httputil/ratelimit.go` | Use `httputil.Do()` — handles 429 + Retry-After (archtest: `no-raw-http`) |
-| Test tier / when to run | `CONTRIBUTING.md` "Test Layering" | L1–L6 table |
+| Test tier / when to run | `CONTRIBUTING.md` "Test Layering" | L1–L5 table |
 | Release process | `.github/workflows/` | Tag-driven, release-notes template |
 
 ## Project-specific conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,21 +30,20 @@ See [issues labeled `good first issue`](https://github.com/openbootdotdev/openbo
 
 ## Test Layering
 
-Tests are split across six tiers. Which one runs where:
+Tests are split across five tiers. Which one runs where:
 
 | Tier | What | How to run | When it runs |
 |------|------|------------|--------------|
-| **L1 Unit / Contract** | Pure-Go logic + command runners faked via `Runner` interface (no fork, no network) | `make test-unit` (~15s) | Every commit (pre-push hook); CI on push/PR |
-| **L2 Integration** | Real `brew` / `git` / `npm` against temp dirs; real `httptest` servers | `make test-integration` (~75s) | CI on push/PR |
-| **L3 Contract schema** | JSON schema validation against [openboot-contract](https://github.com/openbootdotdev/openboot-contract) | (runs in CI only) | CI on push/PR |
-| **L4 E2E binary** | Compiled binary driven by scripts; `-tags=e2e` | `make test-e2e` | CI on release |
-| **L5 Destructive macOS** | Runs against a real macOS host (installs packages, modifies `~/.zshrc`, writes `defaults`) | `make test-vm-quick` / `test-vm-release` / `test-vm-full` — requires `CI=true` or `OPENBOOT_E2E_DESTRUCTIVE=1` | GH Actions `macos-latest` on release tags + manual dispatch |
-| **L6 Destructive** | Actually installs real packages into a real system | `make test-destructive` / `test-smoke` | CI on release, plus manual `workflow_dispatch` |
+| **L1 Unit + Integration + Contract** | Pure-Go logic with faked `Runner` *plus* real `brew` / `git` / `npm` against temp dirs and real `httptest` servers | `make test-unit` (~75s) | Every push (pre-push hook); CI on push/PR |
+| **L2 Contract schema** | JSON schema validation against [openboot-contract](https://github.com/openbootdotdev/openboot-contract) | (runs in CI only) | CI on push/PR |
+| **L3 E2E binary** | Compiled binary driven by scripts; `-tags=e2e` | `make test-e2e` | CI on release |
+| **L4 Destructive macOS** | Runs against a real macOS host (installs packages, modifies `~/.zshrc`, writes `defaults`) | `make test-vm-quick` / `test-vm-release` / `test-vm-full` — requires `CI=true` or `OPENBOOT_E2E_DESTRUCTIVE=1` | GH Actions `macos-latest` on release tags + manual dispatch |
+| **L5 Destructive** | Actually installs real packages into a real system | `make test-destructive` / `test-smoke` | CI on release, plus manual `workflow_dispatch` |
 
 Rules of thumb:
 
-- **Local dev:** run nothing manually if hooks are installed. `make test-unit` on demand when you want a sanity check. Skip L2+ unless you're touching code that interacts with real brew/git/npm.
-- **Before pushing:** `make test-unit` (the pre-push hook does this automatically).
+- **Local dev:** run nothing manually if hooks are installed. `make test-unit` on demand when you want a sanity check. Skip L2+ unless you're cutting a release.
+- **Before pushing:** `make test-unit` (the pre-push hook does this automatically). Requires `brew` / `git` / `npm` on PATH — they are queried read-only against temp dirs, no real installs.
 - **Before tagging a release:** trigger the `macos-e2e` job via GitHub Actions (manual dispatch or tag push). To run locally on a throwaway macOS machine: `OPENBOOT_E2E_DESTRUCTIVE=1 make test-vm-release`.
 
 ## Git Hooks
@@ -52,7 +51,7 @@ Rules of thumb:
 `make install-hooks` symlinks two hooks from `scripts/hooks/` into `.git/hooks/`:
 
 - **pre-commit** (<5s) — `go vet` + `go build`. Early-exits when no `.go` files are staged.
-- **pre-push** (~15s) — `go test -race ./...` (L1 suite).
+- **pre-push** (~75s) — `go test -race ./...` (L1 suite: unit + integration + contract).
 
 Skip once with git's standard bypass flag. Remove entirely with `make uninstall-hooks`.
 
@@ -64,7 +63,7 @@ Skip once with git's standard bypass flag. Remove entirely with `make uninstall-
 
 **Don't assume filesystem state.** Use `t.TempDir()` and `t.Setenv("HOME", t.TempDir())` when code reads `~/.something`.
 
-Integration tests (L2) *may* touch the real filesystem but only inside temp dirs, and they must not depend on the developer's `~/.dotfiles`, `~/.zshrc`, or similar.
+Integration tests live alongside L1 in `test/integration/` and *may* touch the real filesystem but only inside temp dirs. They must not depend on the developer's `~/.dotfiles`, `~/.zshrc`, or similar, and must only read (never install/uninstall) real `brew` / `npm` / `git` state.
 
 ## Code Expectations
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-unit test-integration test-e2e test-destructive test-smoke test-smoke-prebuilt test-coverage test-all \
+.PHONY: test-unit test-e2e test-destructive test-smoke test-smoke-prebuilt test-coverage test-all \
        test-vm test-vm-run test-vm-quick test-vm-release test-vm-full \
        install-hooks uninstall-hooks
 
@@ -14,9 +14,6 @@ test-unit:
 
 lint:
 	golangci-lint run ./...
-
-test-integration:
-	go test -v -timeout 5m -tags=integration ./...
 
 test-e2e: build
 	go test -v -tags=e2e -short ./...
@@ -39,7 +36,6 @@ test-coverage:
 test-all:
 	@echo "Running all tests..."
 	$(MAKE) test-unit
-	$(MAKE) test-integration
 	$(MAKE) test-coverage
 
 # =============================================================================
@@ -101,7 +97,7 @@ clean:
 #   make install-hooks
 #
 # pre-commit: go vet + go build   (<5s, runs on every commit)
-# pre-push:   go test ./...       (~15s L1 unit+contract, runs on every push)
+# pre-push:   go test ./...       (~75s L1 unit + integration + contract, runs on every push)
 #
 # Skip once:  git commit --no-verify  |  git push --no-verify
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -44,12 +44,11 @@ Three regulation categories:
 | Arch. | `no-direct-exec` | L1 (`make test-unit`) | `internal/archtest/exec_test.go` |
 | Arch. | `no-raw-http` | L1 | `internal/archtest/http_test.go` |
 | Arch. | `no-os-getenv-home` | L1 | `internal/archtest/envhome_test.go` |
-| Behav. | L1 unit + contract | pre-push, CI | `make test-unit` |
-| Behav. | L2 integration (real brew/git/npm in temp dirs) | CI | `make test-integration` |
-| Behav. | L3 contract schema (against openboot-contract repo) | CI | `.github/workflows/test.yml` `contract` job |
-| Behav. | L4 e2e binary | release | `make test-e2e` |
-| Behav. | L5 macOS e2e (`vm`) | release tags, manual dispatch | `make test-vm-release` |
-| Behav. | L6 destructive (real installs) | release tags, manual dispatch | `make test-destructive` |
+| Behav. | L1 unit + integration + contract (faked runners *and* real brew/git/npm in temp dirs) | pre-push, CI | `make test-unit` |
+| Behav. | L2 contract schema (against openboot-contract repo) | CI | `.github/workflows/test.yml` `contract` job |
+| Behav. | L3 e2e binary | release | `make test-e2e` |
+| Behav. | L4 macOS e2e (`vm`) | release tags, manual dispatch | `make test-vm-release` |
+| Behav. | L5 destructive (real installs) | release tags, manual dispatch | `make test-destructive` |
 | Behav. | curl\|bash smoke (install.sh + mock server) | every PR | `.github/workflows/test.yml` `curl-bash-smoke` job |
 | Behav. | Old-CLI compat (previous release × current mock server) | every PR | `.github/workflows/test.yml` `cli-compat` job |
 | Feedfwd. | Agent conventions | every AI turn | `CLAUDE.md`, `AGENTS.md` |
@@ -70,7 +69,7 @@ When you observe a recurring issue, decide where to encode the fix:
 | "Agent keeps calling `exec.Command` from a feature package." | New entry in `execAllowedPaths` *or* refactor + update baseline. The rule itself is already in `internal/archtest`. |
 | "Agent doesn't know about preset X." | Update `internal/config/data/presets.yaml`. Source of truth, not docs. |
 | "Agent introduced a new lint failure that golangci-lint should have caught." | Enable the relevant linter in `.golangci.yml`. |
-| "Agent broke a behaviour that has no test." | Write the test at the right tier (usually L1 unit; L2 if it requires real subprocess). |
+| "Agent broke a behaviour that has no test." | Write the test at the right tier — L1 covers both faked-runner units in `internal/<pkg>/` and real-subprocess integration in `test/integration/`. |
 | "Agent missed a CLAUDE.md rule we keep restating." | Make it a hard or soft archtest rule (a docs rule that doesn't fail is a docs rule that drifts). |
 | "Agent did something safe but suboptimal." | Add to CLAUDE.md "Project-specific conventions" and consider whether it's encodable. |
 | "Agent guessed at an API contract." | Update `openboot-contract` repo + fixtures; CI already runs schema validation. |

--- a/docs/MERGE_POLICY.md
+++ b/docs/MERGE_POLICY.md
@@ -17,9 +17,8 @@ the merge commit's tip:
 | Check | Workflow | Why required |
 |---|---|---|
 | `lint` | Test | Catches gofmt / gosec / staticcheck issues that block release builds. |
-| `unit (L1)` | Test | The fast Go unit + contract suite. Includes `internal/archtest` fitness rules. |
-| `integration (L2)` | Test | Real `brew` / `git` / `npm` in temp dirs. Catches integration drift the unit suite can't. |
-| `contract schema (L3)` | Test | Validates remote-config / snapshot JSON against the `openboot-contract` schemas. Breaking the contract breaks live users. |
+| `unit (L1)` | Test | Unit + integration + contract: faked-runner Go tests *and* real `brew` / `git` / `npm` against temp dirs. Includes `internal/archtest` fitness rules. |
+| `contract schema (L2)` | Test | Validates remote-config / snapshot JSON against the `openboot-contract` schemas. Breaking the contract breaks live users. |
 | `curl\|bash smoke` | Test | Confirms `scripts/install.sh` still bootstraps the CLI against a mock server. |
 | `old-cli compat` | Test | Runs the **previous** release binary against the **current** mock server. Catches server-side changes that would break already-shipped CLIs in the field. |
 
@@ -27,7 +26,7 @@ the merge commit's tip:
 
 | Check | Status | Reason |
 |---|---|---|
-| `macos e2e (L5)` | runs only on tag pushes / manual dispatch | Slow + destructive; runs at release time, not per PR. |
+| `macos e2e (L4)` | runs only on tag pushes / manual dispatch | Slow + destructive; runs at release time, not per PR. |
 | Harness drift sensors (`govulncheck`, `deadcode`, `mod-tidy diff`, `archtest stale baseline`) | `continue-on-error: true` | Informational by design. Failures surface as annotations and, on `main`, open tracking issues via `drift-to-issue.yml`. |
 | `codecov/patch` | informational | Coverage threshold is a guideline, not a gate. Hard coverage gates push toward test-shaped code without raising actual quality. |
 
@@ -45,16 +44,16 @@ the merge commit's tip:
   add it to this list. Promote a check to required by editing this doc
   and updating branch protection in the same PR.
 
-## Why these six
+## Why these five
 
 Each required check covers a class of regression that has shipped to
 users in past commits:
 
 - `lint` blocks PRs that fail `golangci-lint` (would block release build).
-- `unit (L1)` is the cheapest, broadest behaviour check.
-- `integration (L2)` catches real-subprocess bugs (brew flags changing,
-  `git` exit codes shifting between macOS versions).
-- `contract schema (L3)` is the contract with the openboot.dev API — any
+- `unit (L1)` is the broadest behaviour check — covers both faked-runner
+  unit logic and real-subprocess integration drift (brew flag changes,
+  `git` exit-code shifts between macOS versions).
+- `contract schema (L2)` is the contract with the openboot.dev API — any
   drift breaks every CLI in the field.
 - `curl|bash smoke` covers the **primary install path** for new users.
   Breaking this is a silent acquisition disaster.

--- a/internal/permissions/screen_recording_test.go
+++ b/internal/permissions/screen_recording_test.go
@@ -5,7 +5,7 @@
 // binary with macOS TCC) and `open x-apple.systempreferences:...` (which
 // pops up System Settings) — both have real side effects and violate the
 // L1 "no real network, no real fork" contract. Coverage for the cgo path
-// belongs in L6 / manual verification.
+// belongs in L5 / manual verification.
 
 package permissions
 

--- a/internal/sync/AGENTS.md
+++ b/internal/sync/AGENTS.md
@@ -83,7 +83,7 @@ Error handling: Collects all errors via `errors.Join` (continues on failure).
 
 - Pure logic functions (diffLists, ToSet, HasChanges, Totals, TotalActions, IsEmpty) have 100% coverage
 - `getLocalDotfilesURL` tested with temp git repo at 80%
-- `ComputeDiff` and `Execute` depend on external commands (brew, npm, git) — not unit-testable without interface refactoring. Use `make test-integration` for these.
+- `ComputeDiff` and `Execute` depend on external commands (brew, npm, git) — not unit-testable without interface refactoring. Exercise them via real-subprocess tests in `test/integration/` (run as part of L1, `make test-unit`).
 - Source persistence tested with `t.TempDir()` + `t.Setenv("HOME", tmpDir)` pattern
 
 ## WHEN MODIFYING

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,7 +1,8 @@
 #!/bin/sh
 #
-# pre-push: run the full L1 unit/contract suite before pushing.
-# Typical runtime: ~15s. Skips L2 integration and L3+ E2E — those run in CI.
+# pre-push: run the full L1 suite (unit + integration + contract) before pushing.
+# Typical runtime: ~75s. Skips L2+ E2E — those run in CI.
+# Requires brew / git / npm on PATH (read-only queries in temp dirs; no installs).
 #
 # To skip once:  git push --no-verify
 # To uninstall:  rm .git/hooks/pre-push
@@ -15,7 +16,7 @@ while read local_ref local_sha remote_ref remote_sha; do
 	fi
 done
 
-echo "→ go test ./... (L1: unit + contract)"
+echo "→ go test ./... (L1: unit + integration + contract)"
 go test -race -count=1 ./...
 
 exit 0

--- a/test/integration/brew_ops_test.go
+++ b/test/integration/brew_ops_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (

--- a/test/integration/brew_ops_test.go
+++ b/test/integration/brew_ops_test.go
@@ -3,9 +3,10 @@ package integration
 import (
 	"testing"
 
-	"github.com/openbootdotdev/openboot/internal/brew"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openbootdotdev/openboot/internal/brew"
 )
 
 func TestIntegration_Brew_IsInstalled(t *testing.T) {

--- a/test/integration/brew_parsing_test.go
+++ b/test/integration/brew_parsing_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (

--- a/test/integration/diff_integration_test.go
+++ b/test/integration/diff_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (

--- a/test/integration/diff_integration_test.go
+++ b/test/integration/diff_integration_test.go
@@ -3,10 +3,11 @@ package integration
 import (
 	"testing"
 
-	"github.com/openbootdotdev/openboot/internal/diff"
-	"github.com/openbootdotdev/openboot/internal/snapshot"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openbootdotdev/openboot/internal/diff"
+	"github.com/openbootdotdev/openboot/internal/snapshot"
 )
 
 func TestIntegration_Diff_SystemVsItself(t *testing.T) {

--- a/test/integration/npm_parsing_test.go
+++ b/test/integration/npm_parsing_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (

--- a/test/integration/snapshot_integration_test.go
+++ b/test/integration/snapshot_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (

--- a/test/integration/snapshot_integration_test.go
+++ b/test/integration/snapshot_integration_test.go
@@ -11,9 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openbootdotdev/openboot/internal/snapshot"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openbootdotdev/openboot/internal/snapshot"
 )
 
 // TestIntegration_SnapshotSaveLoad tests snapshot file I/O operations.

--- a/test/integration/sync_integration_test.go
+++ b/test/integration/sync_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (

--- a/test/integration/sync_integration_test.go
+++ b/test/integration/sync_integration_test.go
@@ -3,10 +3,11 @@ package integration
 import (
 	"testing"
 
-	"github.com/openbootdotdev/openboot/internal/config"
-	syncpkg "github.com/openbootdotdev/openboot/internal/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openbootdotdev/openboot/internal/config"
+	syncpkg "github.com/openbootdotdev/openboot/internal/sync"
 )
 
 func TestIntegration_Execute_DryRun_EmptyPlan(t *testing.T) {
@@ -75,7 +76,7 @@ func TestIntegration_Execute_DryRun_FullPlan(t *testing.T) {
 		InstallNpm:        []string{"turbo"},
 		InstallTaps:       []string{"homebrew/cask-fonts"},
 		UninstallFormulae: []string{"htop"},
-		UpdateDotfiles: "https://github.com/user/dots",
+		UpdateDotfiles:    "https://github.com/user/dots",
 		UpdateMacOSPrefs: []config.RemoteMacOSPref{
 			{Domain: "com.apple.dock", Key: "autohide", Value: "true"},
 		},

--- a/test/integration/updater_integration_test.go
+++ b/test/integration/updater_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (

--- a/test/integration/updater_integration_test.go
+++ b/test/integration/updater_integration_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openbootdotdev/openboot/internal/updater"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openbootdotdev/openboot/internal/updater"
 )
 
 func TestIntegration_Updater_IsHomebrewInstall(t *testing.T) {


### PR DESCRIPTION
## Summary

- Drop `//go:build integration` from `test/integration/*.go` so real-subprocess tests run as part of `make test-unit` and the pre-push hook. Closes the gap that integration drift could land on `main` without local feedback.
- Pre-push runtime: ~15s → ~75s. L1 now spans unit + integration + contract.
- Renumber tiers to close the gap: `contract schema` L3→L2, `e2e` L4→L3, `vm` L5→L4, `destructive` L6→L5.
- Drop the dedicated `integration (L2)` CI job (unit job now covers it); extract the optional destructive step into its own gated job.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race -count=1 -timeout 5m ./...` green locally (includes `test/integration` 43.5s)
- [x] Stale references scanned (`L6`, `test-integration`, `//go:build integration`, old job names) — none remain
- [ ] CI: `lint`, `unit (L1)`, `contract schema (L2)`, `curl|bash smoke`, `old-cli compat`

## Notes

`internal/macos/categories.go` had a separate unrelated change (Control Center menu-bar prefs) in the working tree at session start — intentionally **not** included in this PR.