### PR TITLE
feat(macos): manage menu bar "Always Show" dropdown for visible modules

### DIFF
--- a/internal/macos/categories.go
+++ b/internal/macos/categories.go
@@ -125,6 +125,12 @@ var DefaultCategories = []PrefCategory{
 			{"com.apple.controlcenter", "NSStatusItem Visible FocusModes", "bool", "false", "Hide Focus Modes from menu bar"},
 			{"com.apple.controlcenter", "NSStatusItem Visible NowPlaying", "bool", "false", "Hide Now Playing from menu bar"},
 			{"com.apple.controlcenter", "NSStatusItem Visible ScreenMirroring", "bool", "false", "Hide Screen Mirroring from menu bar"},
+			// Mode dropdown: 2 = "Show When Active" (macOS default), 18 = "Always Show in Menu Bar".
+			// Without this, visible modules fall back to "Show When Active" — e.g. Sound only appears while playing.
+			{"com.apple.controlcenter", "Sound", "int", "18", "Always show Sound in menu bar (not only when active)"},
+			{"com.apple.controlcenter", "Bluetooth", "int", "18", "Always show Bluetooth in menu bar"},
+			{"com.apple.controlcenter", "WiFi", "int", "18", "Always show Wi-Fi in menu bar"},
+			{"com.apple.controlcenter", "Battery", "int", "18", "Always show Battery in menu bar"},
 		},
 	},
 	{

--- a/internal/macos/categories.go
+++ b/internal/macos/categories.go
@@ -125,8 +125,8 @@ var DefaultCategories = []PrefCategory{
 			{"com.apple.controlcenter", "NSStatusItem Visible FocusModes", "bool", "false", "Hide Focus Modes from menu bar"},
 			{"com.apple.controlcenter", "NSStatusItem Visible NowPlaying", "bool", "false", "Hide Now Playing from menu bar"},
 			{"com.apple.controlcenter", "NSStatusItem Visible ScreenMirroring", "bool", "false", "Hide Screen Mirroring from menu bar"},
-			// Mode dropdown: 2 = "Show When Active" (macOS default), 18 = "Always Show in Menu Bar".
-			// Without this, visible modules fall back to "Show When Active" — e.g. Sound only appears while playing.
+			// Mode dropdown: int 18 = "Always Show in Menu Bar". When the key is absent,
+			// macOS defaults to "Show When Active" — e.g. Sound only appears while playing.
 			{"com.apple.controlcenter", "Sound", "int", "18", "Always show Sound in menu bar (not only when active)"},
 			{"com.apple.controlcenter", "Bluetooth", "int", "18", "Always show Bluetooth in menu bar"},
 			{"com.apple.controlcenter", "WiFi", "int", "18", "Always show Wi-Fi in menu bar"},


### PR DESCRIPTION
## Summary

- The Menu Bar catalog only managed the visibility checkbox (`NSStatusItem Visible X`); the mode dropdown was left at macOS's default of "Show When Active", so Sound/Bluetooth/Wi-Fi/Battery would still hide themselves when the underlying state was inactive.
- Add `com.apple.controlcenter` / `<Module>` (int, value `18` = "Always Show in Menu Bar") for the four modules currently set visible. Modules with `Visible=false` don't need the mode key — the checkbox already hides them entirely.

## Test plan

- [x] `go test ./internal/...` (L1 incl. archtest + categories_test) — green
- [x] `go vet ./...` — clean
- [x] Empirically verified on macOS Sequoia: `defaults write com.apple.controlcenter Sound -int 18 && killall ControlCenter` flips the dropdown to "Always Show in Menu Bar"