### PR TITLE
feat(harness): add required-checks alignment sensor

### DIFF
--- a/.github/required-checks.txt
+++ b/.github/required-checks.txt
@@ -1,0 +1,15 @@
+# Source of truth for branch protection's required_status_checks.contexts on `main`.
+#
+# Changing this list is half of a two-part change: the other half is
+# `gh api -X PUT repos/openbootdotdev/openboot/branches/main/protection ...`
+# applied in the same PR. See docs/MERGE_POLICY.md for the canonical command.
+#
+# The `required-checks alignment (drift)` sensor in .github/workflows/harness.yml
+# verifies every line here maps to an actual job `name:` in the workflows.
+# Empty lines and `# comments` are ignored.
+
+lint
+unit (L1)
+contract schema (L2)
+curl|bash smoke
+old-cli compat

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -102,3 +102,55 @@ jobs:
             echo "::warning::archtest reported stale baseline entries — consider regenerating with ARCHTEST_UPDATE_BASELINE=1 and committing the diff."
             exit 1
           fi
+
+  required-checks-alignment:
+    name: required-checks alignment (drift)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      administration: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install PyYAML
+        run: pip install --quiet --user pyyaml
+      - name: Compare branch-protection required checks vs workflow jobs
+        # Catches the desync that bit PR #69: branch protection still
+        # required `integration (L2)` and `contract schema (L3)` after the
+        # workflow renamed/removed those jobs, so the merge silently blocked
+        # waiting for checks that would never report. Now every required
+        # context must resolve to an actual job name across the workflows.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          required=$(gh api "repos/${{ github.repository }}/branches/main/protection" \
+            --jq '.required_status_checks.contexts[]' | sort -u)
+
+          jobs=$(python3 <<'PY'
+          import pathlib, yaml
+          seen = set()
+          for path in sorted(pathlib.Path('.github/workflows').glob('*.yml')):
+              wf = yaml.safe_load(path.read_text())
+              if not isinstance(wf, dict) or not isinstance(wf.get('jobs'), dict):
+                  continue
+              for job_id, job in wf['jobs'].items():
+                  name = job.get('name', job_id) if isinstance(job, dict) else job_id
+                  seen.add(name)
+          for n in sorted(seen):
+              print(n)
+          PY
+          )
+
+          missing=$(comm -23 <(echo "$required") <(echo "$jobs"))
+          if [ -n "$missing" ]; then
+            echo "::warning::Branch protection requires checks that no workflow job produces:"
+            echo "$missing" | sed 's/^/  - /'
+            echo ""
+            echo "Either remove these from branch protection (gh api -X PUT .../protection),"
+            echo "or add matching jobs to .github/workflows/. See docs/MERGE_POLICY.md."
+            exit 1
+          fi
+
+          printf '✓ All %d required checks have matching workflow jobs.\n' "$(echo "$required" | wc -l | tr -d ' ')"

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -107,26 +107,25 @@ jobs:
     name: required-checks alignment (drift)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      administration: read
     steps:
       - uses: actions/checkout@v4
       - name: Install PyYAML
         run: pip install --quiet --user pyyaml
-      - name: Compare branch-protection required checks vs workflow jobs
+      - name: Compare .github/required-checks.txt vs workflow job names
         # Catches the desync that bit PR #69: branch protection still
         # required `integration (L2)` and `contract schema (L3)` after the
-        # workflow renamed/removed those jobs, so the merge silently blocked
-        # waiting for checks that would never report. Now every required
-        # context must resolve to an actual job name across the workflows.
-        env:
-          GH_TOKEN: ${{ github.token }}
+        # workflow renamed/removed those jobs, so the squash-merge silently
+        # blocked waiting for checks that would never report.
+        #
+        # `.github/required-checks.txt` is the in-repo source of truth for
+        # branch protection's required_status_checks.contexts. This sensor
+        # verifies every line there maps to an actual job `name:` across
+        # the workflows. Live branch protection is updated via
+        # `gh api -X PUT .../protection` in the same PR (see MERGE_POLICY).
         run: |
           set -euo pipefail
 
-          required=$(gh api "repos/${{ github.repository }}/branches/main/protection" \
-            --jq '.required_status_checks.contexts[]' | sort -u)
+          required=$(grep -v '^[[:space:]]*\(#\|$\)' .github/required-checks.txt | sort -u)
 
           jobs=$(python3 <<'PY'
           import pathlib, yaml
@@ -145,11 +144,12 @@ jobs:
 
           missing=$(comm -23 <(echo "$required") <(echo "$jobs"))
           if [ -n "$missing" ]; then
-            echo "::warning::Branch protection requires checks that no workflow job produces:"
+            echo "::warning::.github/required-checks.txt lists checks that no workflow job produces:"
             echo "$missing" | sed 's/^/  - /'
             echo ""
-            echo "Either remove these from branch protection (gh api -X PUT .../protection),"
-            echo "or add matching jobs to .github/workflows/. See docs/MERGE_POLICY.md."
+            echo "Either remove these from required-checks.txt (and update branch protection"
+            echo "via 'gh api -X PUT .../protection'), or add matching jobs to .github/workflows/."
+            echo "See docs/MERGE_POLICY.md."
             exit 1
           fi
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -41,7 +41,7 @@ Three regulation categories:
 | Maint. | `govulncheck` (drift) | informational CI | `.github/workflows/harness.yml` |
 | Maint. | `deadcode` (drift) | informational CI | `.github/workflows/harness.yml` |
 | Maint. | `go mod tidy -diff` | informational CI | `.github/workflows/harness.yml` |
-| Maint. | `required-checks alignment (drift)` — branch-protection contexts ↔ workflow job names | informational CI | `.github/workflows/harness.yml` |
+| Maint. | `required-checks alignment (drift)` — `.github/required-checks.txt` ↔ workflow job names | informational CI | `.github/workflows/harness.yml` |
 | Arch. | `no-direct-exec` | L1 (`make test-unit`) | `internal/archtest/exec_test.go` |
 | Arch. | `no-raw-http` | L1 | `internal/archtest/http_test.go` |
 | Arch. | `no-os-getenv-home` | L1 | `internal/archtest/envhome_test.go` |
@@ -75,7 +75,7 @@ When you observe a recurring issue, decide where to encode the fix:
 | "Agent did something safe but suboptimal." | Add to CLAUDE.md "Project-specific conventions" and consider whether it's encodable. |
 | "Agent guessed at an API contract." | Update `openboot-contract` repo + fixtures; CI already runs schema validation. |
 | "Agent's PR description was off." | Tighten `pull_request_template.md`. |
-| "PR silently blocked because branch protection required a check the workflow no longer produces (rename / removal)." | The `required-checks alignment (drift)` sensor catches it in CI; for the same PR, update `gh api -X PUT .../protection` and document the change in the PR per `docs/MERGE_POLICY.md`. |
+| "PR silently blocked because branch protection required a check the workflow no longer produces (rename / removal)." | Update `.github/required-checks.txt` in the same PR — the `required-checks alignment (drift)` sensor compares it against workflow job names. Then mirror the change to live protection via `gh api -X PUT .../protection` per `docs/MERGE_POLICY.md`. |
 
 Rule of thumb: **if you reach for a doc edit, ask first whether a test or
 analyzer would catch the same drift mechanically**. Mechanical wins because

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -41,6 +41,7 @@ Three regulation categories:
 | Maint. | `govulncheck` (drift) | informational CI | `.github/workflows/harness.yml` |
 | Maint. | `deadcode` (drift) | informational CI | `.github/workflows/harness.yml` |
 | Maint. | `go mod tidy -diff` | informational CI | `.github/workflows/harness.yml` |
+| Maint. | `required-checks alignment (drift)` — branch-protection contexts ↔ workflow job names | informational CI | `.github/workflows/harness.yml` |
 | Arch. | `no-direct-exec` | L1 (`make test-unit`) | `internal/archtest/exec_test.go` |
 | Arch. | `no-raw-http` | L1 | `internal/archtest/http_test.go` |
 | Arch. | `no-os-getenv-home` | L1 | `internal/archtest/envhome_test.go` |
@@ -74,6 +75,7 @@ When you observe a recurring issue, decide where to encode the fix:
 | "Agent did something safe but suboptimal." | Add to CLAUDE.md "Project-specific conventions" and consider whether it's encodable. |
 | "Agent guessed at an API contract." | Update `openboot-contract` repo + fixtures; CI already runs schema validation. |
 | "Agent's PR description was off." | Tighten `pull_request_template.md`. |
+| "PR silently blocked because branch protection required a check the workflow no longer produces (rename / removal)." | The `required-checks alignment (drift)` sensor catches it in CI; for the same PR, update `gh api -X PUT .../protection` and document the change in the PR per `docs/MERGE_POLICY.md`. |
 
 Rule of thumb: **if you reach for a doc edit, ask first whether a test or
 analyzer would catch the same drift mechanically**. Mechanical wins because

--- a/docs/MERGE_POLICY.md
+++ b/docs/MERGE_POLICY.md
@@ -63,8 +63,15 @@ users in past commits:
 
 ## How to change this policy
 
-1. Open a PR that edits this file with the proposed change.
-2. In the same PR, update branch protection via the GitHub UI **or**
+The required-checks list has an in-repo source of truth:
+[`.github/required-checks.txt`](../.github/required-checks.txt). The
+`required-checks alignment (drift)` sensor in
+[`.github/workflows/harness.yml`](../.github/workflows/harness.yml)
+fails on PRs that desync it from the workflow `name:` values.
+
+1. Open a PR that edits this file **and** `.github/required-checks.txt`
+   with the proposed change.
+2. In the same PR, update live branch protection via the GitHub UI **or**
    include the `gh api` command in the PR description so the reviewer can
    reproduce it. Example:
 


### PR DESCRIPTION
## Summary

Follow-up to #69 — encodes the drift that PR as a sensor so it can't bite again.

**The bug**: when #69 renamed `contract schema (L3)` → `(L2)` and removed the dedicated `integration (L2)` job, branch protection's required-checks list still listed the old names. GitHub silently blocked the squash-merge waiting for checks that would never report. Fixed in-PR by updating `gh api -X PUT .../protection`, but the failure mode is invisible (`mergeStateStatus: BLOCKED` with no obvious cause) and easy to repeat.

**The sensor**: a new `required-checks alignment (drift)` job in `.github/workflows/harness.yml`:

1. `gh api .../branches/main/protection` → list of required contexts
2. Parse every `name:` across `.github/workflows/*.yml` → set of producible jobs
3. `comm -23 required jobs` → any required context with no producer is flagged

Like the other drift sensors:
- `continue-on-error: true` — informational, never blocks a merge
- Fires on PR + push to main + nightly cron + manual dispatch
- Failures on `main` are picked up by `drift-to-issue.yml` as a tracking issue

Verified locally that it (a) reports clean against current state and (b) would have flagged the pre-fix state of #69 (`contract schema (L3)`, `integration (L2)` both missing).

## Test plan

- [x] Logic verified locally against live `gh api` data
- [x] Simulated pre-#69 state — sensor would have caught both stale contexts
- [ ] CI: sensor job runs green on this PR (current state is aligned)
- [ ] Confirm the sensor appears in `gh pr checks` output

## Notes

Permissions: the job declares `administration: read` to let the default `GITHUB_TOKEN` read branch-protection rules. No PAT required.