### PR TITLE
fix(sync): skip Unset local prefs so remote drives the write

### DIFF
--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -200,20 +200,36 @@ func diffMacOSPrefs(rc *config.RemoteConfig, d *SyncDiff) error {
 	if err != nil {
 		return fmt.Errorf("capture local macos prefs: %w", err)
 	}
+	d.MacOSChanged = computeMacOSPrefDiff(rc.MacOSPrefs, localPrefs)
+	return nil
+}
 
+// computeMacOSPrefDiff is the pure-logic core of diffMacOSPrefs: given the
+// remote prefs and a captured local pref list, return the prefs that need
+// writing on the local machine.
+//
+// Local prefs marked Unset carry the catalog's default value as a placeholder,
+// not what `defaults read` actually returned. Including them in the lookup
+// makes the diff falsely match a remote pref of the same value, suppressing
+// the write needed to make the key actually exist on disk.
+func computeMacOSPrefDiff(remote []config.RemoteMacOSPref, local []snapshot.MacOSPref) []MacOSPrefDiff {
 	type prefKey struct {
 		Domain string
 		Key    string
 	}
-	localMap := make(map[prefKey]string, len(localPrefs))
-	for _, p := range localPrefs {
+	localMap := make(map[prefKey]string, len(local))
+	for _, p := range local {
+		if p.Unset {
+			continue
+		}
 		localMap[prefKey{p.Domain, p.Key}] = p.Value
 	}
 
-	for _, rp := range rc.MacOSPrefs {
+	var changed []MacOSPrefDiff
+	for _, rp := range remote {
 		localVal, exists := localMap[prefKey{rp.Domain, rp.Key}]
 		if !exists || localVal != rp.Value {
-			d.MacOSChanged = append(d.MacOSChanged, MacOSPrefDiff{
+			changed = append(changed, MacOSPrefDiff{
 				Domain:      rp.Domain,
 				Key:         rp.Key,
 				Type:        rp.Type,
@@ -223,7 +239,7 @@ func diffMacOSPrefs(rc *config.RemoteConfig, d *SyncDiff) error {
 			})
 		}
 	}
-	return nil
+	return changed
 }
 
 // diffLists returns (missing, extra) where missing = in remote but not local,

--- a/internal/sync/diff_extra_test.go
+++ b/internal/sync/diff_extra_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openbootdotdev/openboot/internal/config"
+	"github.com/openbootdotdev/openboot/internal/snapshot"
 )
 
 // ---- diffDotfiles ----
@@ -209,6 +210,49 @@ func TestDiffMacOSPrefs_EmptyPrefsList(t *testing.T) {
 	err := diffMacOSPrefs(rc, d)
 	require.NoError(t, err)
 	assert.Empty(t, d.MacOSChanged)
+}
+
+// ---- computeMacOSPrefDiff (pure-logic core) ----
+
+func TestComputeMacOSPrefDiff_UnsetLocalCountsAsMissing(t *testing.T) {
+	// Regression: a locally captured Unset pref carries the catalog default in
+	// Value as a placeholder. The diff must treat it as "not on the machine"
+	// so the remote pref still drives a write, instead of falsely matching.
+	remote := []config.RemoteMacOSPref{
+		{Domain: "com.apple.controlcenter", Key: "Bluetooth", Type: "int", Value: "18", Desc: "Always show Bluetooth"},
+	}
+	local := []snapshot.MacOSPref{
+		{Domain: "com.apple.controlcenter", Key: "Bluetooth", Type: "int", Value: "18", Unset: true},
+	}
+	changed := computeMacOSPrefDiff(remote, local)
+	require.Len(t, changed, 1)
+	assert.Equal(t, "Bluetooth", changed[0].Key)
+	assert.Equal(t, "18", changed[0].RemoteValue)
+	assert.Empty(t, changed[0].LocalValue, "Unset local pref must not surface its placeholder value")
+}
+
+func TestComputeMacOSPrefDiff_ExplicitLocalMatchesRemote(t *testing.T) {
+	// Sanity: an explicit (non-Unset) local value equal to remote → no diff.
+	remote := []config.RemoteMacOSPref{
+		{Domain: "com.apple.controlcenter", Key: "Sound", Type: "int", Value: "18"},
+	}
+	local := []snapshot.MacOSPref{
+		{Domain: "com.apple.controlcenter", Key: "Sound", Type: "int", Value: "18"},
+	}
+	assert.Empty(t, computeMacOSPrefDiff(remote, local))
+}
+
+func TestComputeMacOSPrefDiff_ExplicitLocalDiffersFromRemote(t *testing.T) {
+	remote := []config.RemoteMacOSPref{
+		{Domain: "com.apple.dock", Key: "autohide", Type: "bool", Value: "true"},
+	}
+	local := []snapshot.MacOSPref{
+		{Domain: "com.apple.dock", Key: "autohide", Type: "bool", Value: "false"},
+	}
+	changed := computeMacOSPrefDiff(remote, local)
+	require.Len(t, changed, 1)
+	assert.Equal(t, "true", changed[0].RemoteValue)
+	assert.Equal(t, "false", changed[0].LocalValue)
 }
 
 // ---- ComputeDiff (pure-logic path — no packages) ----


### PR DESCRIPTION
## Summary

- `diffMacOSPrefs` was including locally-captured `Unset` prefs in the lookup map. Their `Value` is the catalog default placeholder, not what `defaults read` actually returned — so when a remote pref had the same value (the common case after #67/#68), the diff falsely matched and no `defaults write` was issued. Result: the key stayed absent on disk and macOS kept showing the default behaviour (e.g. menu bar Sound/Bluetooth/WiFi/Battery stuck on "Show When Active" after installing a config that explicitly sets them to "Always Show").
- Skip `Unset` prefs from the local lookup map so they count as "missing" and surface in `MacOSChanged`. Matches the existing semantics in `internal/diff/compare.go:diffMacOS` ("Unset prefs on either side mean 'no opinion'").
- Extract the comparison core into `computeMacOSPrefDiff` so the regression is unit-testable without going through real `defaults read`.

## Repro that motivated this

Installing `fullstackjam/jam-s-packages` on a machine where `Bluetooth/WiFi/Battery` were never explicitly set:

- Remote config: `com.apple.controlcenter Bluetooth=18` (Always Show in Menu Bar), same for WiFi/Battery
- Local capture: `Bluetooth` recorded as `Unset` with placeholder value `18` (catalog default)
- Pre-fix diff: `18 == 18` → no diff → no write → `defaults read com.apple.controlcenter Bluetooth` still says "does not exist" after install
- Post-fix: `Bluetooth` surfaces as needing a write; install runs the `defaults write`

## Test plan

- [x] New unit tests in `internal/sync/diff_extra_test.go` exercising the three meaningful cases (Unset local → missing, explicit match → no diff, explicit differ → diff)
- [x] `go test ./internal/...` (L1 incl. archtest) — green
- [x] `go vet ./...` — clean