### PR TITLE
docs(claude): document worktree-per-session workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@ Core flow: `openboot install` runs a 7-step wizard in `internal/installer/instal
 For full contribution guide (test layering L1–L5, Runner interface, hook setup) see @CONTRIBUTING.md.
 For AI agents: @AGENTS.md indexes invariants enforced by `internal/archtest`; @docs/HARNESS.md is the steering meta-doc for where to encode new rules.
 
+## Working in parallel
+
+This repo is often worked on from multiple concurrent terminals / agent sessions. Default to `git worktree add ../openboot-<topic> -b <branch>` rather than juggling branches in a single checkout — two sessions racing on the same working tree corrupts state (mid-edit files, half-staged diffs, hooks firing against the wrong branch). One worktree per concurrent task; remove it with `git worktree remove` when the PR merges.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a short "Working in parallel" section to `CLAUDE.md` instructing future agents to default to `git worktree add ../openboot-<topic> -b <branch>` when multiple sessions touch this repo concurrently.

## Why

Multiple terminals / agent sessions sharing one checkout race on the working tree: mid-edit files clobber each other, hooks fire against the wrong branch, half-staged diffs leak between sessions. One worktree per concurrent task makes that impossible.

## Test plan

- [x] CLAUDE.md renders cleanly (markdown only).
- [x] No code changes — L1 / archtest not affected.