### PR TITLE
feat(harness): add auto-release sensor

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,135 @@
+name: Auto Release
+
+# Sensor: when unreleased commits on main trip a threshold, automatically tag
+# the next version and dispatch release.yml. Closes the "agent forgot to cut
+# a release" loop — see docs/HARNESS.md.
+#
+# Triggers (any one fires):
+#   - >=5 feat/fix commits since last stable tag
+#   - >=7 days since last stable tag AND new commits exist
+#   - any fix: present (patch fast lane)
+#
+# Version bump:
+#   - any feat: present -> minor (X.Y+1.0)
+#   - else              -> patch (X.Y.Z+1)
+#
+# Why we dispatch release.yml instead of relying on the tag-push trigger:
+# GitHub deliberately suppresses workflow events fired by GITHUB_TOKEN, so a
+# tag pushed from here would NOT start release.yml. We push the tag and then
+# explicitly `gh workflow run release.yml -f version=<tag>`.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run: compute decision and exit without tagging.'
+        type: boolean
+        default: true
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  evaluate:
+    name: auto-release sensor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Decide
+        id: decide
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          last_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+            | grep -Ev -- '-(rc|beta|alpha)' \
+            | head -n1 || true)
+          if [ -z "$last_tag" ]; then
+            echo "::warning::no stable tag found — skipping auto-release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "last_tag=$last_tag"
+
+          commits=$(git log --format='%s' "${last_tag}..HEAD")
+          if [ -z "$commits" ]; then
+            echo "no commits since $last_tag — skip"
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          feat_count=$(printf '%s\n' "$commits" | grep -cE '^feat(\(.+\))?!?:' || true)
+          fix_count=$(printf '%s\n' "$commits" | grep -cE '^fix(\(.+\))?!?:' || true)
+          combined=$((feat_count + fix_count))
+
+          last_ts=$(git log -1 --format=%ct "$last_tag")
+          now=$(date -u +%s)
+          days=$(( (now - last_ts) / 86400 ))
+
+          echo "feat=$feat_count fix=$fix_count combined=$combined days_since=$days"
+
+          reason=""
+          if [ "$combined" -ge 5 ]; then
+            reason="${combined} feat/fix commits since ${last_tag}"
+          elif [ "$days" -ge 7 ]; then
+            reason="${days} days since ${last_tag} with new commits"
+          elif [ "$fix_count" -ge 1 ]; then
+            reason="fix present (patch fast lane)"
+          else
+            echo "no threshold tripped — skip"
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IFS='.' read -r major minor patch <<<"${last_tag#v}"
+          if [ "$feat_count" -ge 1 ]; then
+            minor=$((minor + 1))
+            patch=0
+            bump="minor"
+          else
+            patch=$((patch + 1))
+            bump="patch"
+          fi
+          new_tag="v${major}.${minor}.${patch}"
+          echo "decision: release ${new_tag} (${bump}) — ${reason}"
+
+          {
+            echo "release=true"
+            echo "new_tag=${new_tag}"
+            echo "bump=${bump}"
+            echo "reason=${reason}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            echo "::notice::DRY_RUN — would tag ${new_tag} (${reason})"
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag and dispatch release
+        if: steps.decide.outputs.release == 'true' && steps.decide.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ steps.decide.outputs.new_tag }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$NEW_TAG" -m "Auto-release: $REASON"
+          git push origin "$NEW_TAG"
+          gh workflow run release.yml -f version="$NEW_TAG"
+          echo "::notice::tagged $NEW_TAG and dispatched release.yml — $REASON"

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -51,6 +51,7 @@ Three regulation categories:
 | Behav. | L4 macOS e2e (`vm`) | release tags, manual dispatch | `make test-vm-release` |
 | Behav. | L5 destructive (real installs) | release tags, manual dispatch | `make test-destructive` |
 | Behav. | curl\|bash smoke (install.sh + mock server) | every PR | `.github/workflows/test.yml` `curl-bash-smoke` job |
+| Behav. | Auto-release sensor — tag + dispatch `release.yml` when unreleased commits trip a threshold (`>=5 feat/fix`, `>=7 days + new`, or any `fix:` for patch fast lane) | push to `main` | `.github/workflows/auto-release.yml` |
 | Behav. | Old-CLI compat (previous release × current mock server) | every PR | `.github/workflows/test.yml` `cli-compat` job |
 | Feedfwd. | Agent conventions | every AI turn | `CLAUDE.md`, `AGENTS.md` |
 | Feedfwd. | Skills | model-loaded | `.claude/skills/*` |
@@ -75,6 +76,7 @@ When you observe a recurring issue, decide where to encode the fix:
 | "Agent did something safe but suboptimal." | Add to CLAUDE.md "Project-specific conventions" and consider whether it's encodable. |
 | "Agent guessed at an API contract." | Update `openboot-contract` repo + fixtures; CI already runs schema validation. |
 | "Agent's PR description was off." | Tighten `pull_request_template.md`. |
+| "Fixes and features piled up on `main` because nobody told an agent to cut a release." | Already handled: `.github/workflows/auto-release.yml` tags on threshold. Tune the thresholds there rather than re-introducing manual release cadence. |
 | "PR silently blocked because branch protection required a check the workflow no longer produces (rename / removal)." | Update `.github/required-checks.txt` in the same PR — the `required-checks alignment (drift)` sensor compares it against workflow job names. Then mirror the change to live protection via `gh api -X PUT .../protection` per `docs/MERGE_POLICY.md`. |
 
 Rule of thumb: **if you reach for a doc edit, ask first whether a test or


### PR DESCRIPTION
## Summary

New workflow `.github/workflows/auto-release.yml` that closes the "fixes and feats pile up on `main` because nobody told an agent to cut a release" loop.

On push to `main` it computes commits since the last stable tag and releases when **any** threshold trips:

- `>=5` feat/fix commits since last tag
- `>=7` days since last tag AND new commits
- any `fix:` present (patch fast lane)

Version bump rule: **minor** if any `feat:` in the range, else **patch**.

## Heads up

GitHub deliberately suppresses workflow events triggered by `GITHUB_TOKEN`, so a tag pushed from this workflow does **not** auto-fire `release.yml`. We push the annotated tag and then explicitly `gh workflow run release.yml -f version=<tag>`. `release.yml`'s existing `gate-tests` (vet + L1 + destructive on macos-latest) is still the safety net — a broken tag never gets published as a GitHub Release.

`workflow_dispatch` is exposed with `dry_run` defaulted to `true` so the decision logic can be exercised manually without tagging.

Dry-run against `main` (HEAD = 8fcfdc9, after PR #74 merged): would tag **`v0.57.0`** (minor) — fix fast-lane triggers, feats present. Meaning the first push to `main` after this merges will tag immediately.

Also documents the sensor in `docs/HARNESS.md` (controls table + steering-loop row pointing future "agent forgot to release" cases back here rather than re-introducing manual cadence).

## Test plan

- [x] Decision logic verified locally against current `main` state — picks `v0.57.0` (minor) via fix fast-lane.
- [x] YAML parses (`python3 -c 'yaml.safe_load(open(...))'`).
- [x] No Go code changes — L1 / archtest unaffected.
- [ ] First real run after merge: confirm release.yml gets dispatched and gate-tests gates it.