### PR TITLE
feat(install): real-time progress bar for cask downloads via scroll region

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ scripts/
 | Add package category | `openboot.dev/src/lib/package-metadata.ts` | Server is source of truth; CLI fetches `/api/packages` and caches 24h in `~/.openboot/packages-cache.json`. `data/packages.yaml` is fallback only. |
 | Modify presets | `internal/config/data/presets.yaml` | 3 presets: minimal, developer, full |
 | Change brew behavior | `internal/brew/brew.go` + `brew_install.go` | Parallel workers, StickyProgress, Uninstall/UninstallCask |
+| Cask download progress | `internal/brew/cache.go` + `internal/brew/sizecheck.go` | HEAD pre-fetch → poll `brew --cache` for bytes; consumed by `installCasksWithProgress` |
 | Add snapshot data | `internal/snapshot/capture.go` | Extend `CaptureWithProgress` steps |
 | Update self-update | `internal/updater/updater.go` | `AutoUpgrade()` called from `root.go` RunE |
 | Change publish flow | `internal/cli/snapshot_publish.go` (`publishSnapshot`) | Slug resolution |

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -42,7 +42,6 @@ Three regulation categories:
 | Maint. | `deadcode` (drift) | informational CI | `.github/workflows/harness.yml` |
 | Maint. | `go mod tidy -diff` | informational CI | `.github/workflows/harness.yml` |
 | Maint. | `required-checks alignment (drift)` — `.github/required-checks.txt` ↔ workflow job names | informational CI | `.github/workflows/harness.yml` |
-| Maint. | scroll-region progress UI (`internal/ui/scrollregion.go`) | runtime, terminal-dependent | gracefully degrades when `TERM=dumb` or stdout is not a TTY |
 | Arch. | `no-direct-exec` | L1 (`make test-unit`) | `internal/archtest/exec_test.go` |
 | Arch. | `no-raw-http` | L1 | `internal/archtest/http_test.go` |
 | Arch. | `no-os-getenv-home` | L1 | `internal/archtest/envhome_test.go` |
@@ -106,6 +105,11 @@ it survives doc rot.
   the in-session loop (Step 8), the sensor became dead code and was
   removed. If `--auto` ever comes back, the sensor needs to come back
   with it.
+- **No archtest rule for scroll-region usage.** `internal/ui/scrollregion.go`
+  detects support at runtime (`TERM`, TTY, terminal height) and falls back
+  to the inline `\r\033[K` renderer when unavailable. A static rule can't
+  see runtime terminal capabilities, so this stays a runtime concern. The
+  fallback is covered by `TestStickyProgressFallsBackWhenScrollRegionUnsupported`.
 
 ## How agents should think about this file
 

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -42,6 +42,7 @@ Three regulation categories:
 | Maint. | `deadcode` (drift) | informational CI | `.github/workflows/harness.yml` |
 | Maint. | `go mod tidy -diff` | informational CI | `.github/workflows/harness.yml` |
 | Maint. | `required-checks alignment (drift)` — `.github/required-checks.txt` ↔ workflow job names | informational CI | `.github/workflows/harness.yml` |
+| Maint. | scroll-region progress UI (`internal/ui/scrollregion.go`) | runtime, terminal-dependent | gracefully degrades when `TERM=dumb` or stdout is not a TTY |
 | Arch. | `no-direct-exec` | L1 (`make test-unit`) | `internal/archtest/exec_test.go` |
 | Arch. | `no-raw-http` | L1 | `internal/archtest/http_test.go` |
 | Arch. | `no-os-getenv-home` | L1 | `internal/archtest/envhome_test.go` |

--- a/internal/archtest/baseline/no-direct-exec.txt
+++ b/internal/archtest/baseline/no-direct-exec.txt
@@ -2,7 +2,7 @@
 # Each line is <file>:<line> of a known existing violation.
 # Regenerate: ARCHTEST_UPDATE_BASELINE=1 go test ./internal/archtest/...
 internal/auth/login.go:191
-internal/brew/brew_install.go:338
+internal/brew/brew_install.go:361
 internal/cli/snapshot.go:21
 internal/diff/compare.go:247
 internal/diff/compare.go:253

--- a/internal/archtest/baseline/no-direct-exec.txt
+++ b/internal/archtest/baseline/no-direct-exec.txt
@@ -2,7 +2,7 @@
 # Each line is <file>:<line> of a known existing violation.
 # Regenerate: ARCHTEST_UPDATE_BASELINE=1 go test ./internal/archtest/...
 internal/auth/login.go:191
-internal/brew/brew_install.go:361
+internal/brew/brew_install.go:369
 internal/cli/snapshot.go:21
 internal/diff/compare.go:247
 internal/diff/compare.go:253

--- a/internal/brew/brew_install.go
+++ b/internal/brew/brew_install.go
@@ -1,6 +1,7 @@
 package brew
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -158,6 +159,7 @@ func InstallWithProgress(cliPkgs, caskPkgs []string, dryRun bool) (installedForm
 	var allFailed []failedJob
 
 	if len(newCli) > 0 {
+		progress.SetPhase(ui.PhaseFormula)
 		failed := runSerialInstallWithProgress(newCli, progress)
 		failedSet := make(map[string]bool, len(failed))
 		for _, f := range failed {
@@ -189,12 +191,39 @@ func InstallWithProgress(cliPkgs, caskPkgs []string, dryRun bool) (installedForm
 // installCasksWithProgress installs cask packages one by one with progress reporting.
 // Returns the successfully installed cask names and any failed jobs.
 func installCasksWithProgress(pkgs []string, progress *ui.StickyProgress) (installed []string, failed []failedJob) {
+	progress.SetPhase(ui.PhaseCask)
+
+	// Pre-flight HEAD all cask URLs to learn download sizes. Bounded so a
+	// slow CDN doesn't hold up the whole install phase.
+	sizeCtx, sizeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	sizes := FetchCaskSizes(sizeCtx, pkgs)
+	sizeCancel()
+
 	for _, pkg := range pkgs {
 		progress.SetCurrent(pkg)
 		progress.PrintLine("  Installing %s...", pkg)
+
+		// Start tracker for this cask (skip if size unknown — no bar, just spinner).
+		var trackerCancel context.CancelFunc
+		if size, ok := sizes[pkg]; ok && size > 0 {
+			tracker, err := NewCacheTracker(pkg)
+			if err == nil {
+				ctx, cancel := context.WithCancel(context.Background())
+				trackerCancel = cancel
+				go tracker.Run(ctx, func(b int64) {
+					progress.SetCurrentBytes(b, size)
+				})
+			}
+		}
+
 		start := time.Now()
 		errMsg := installCaskWithProgress(pkg, progress)
 		elapsed := time.Since(start)
+
+		if trackerCancel != nil {
+			trackerCancel()
+		}
+
 		progress.IncrementWithStatus(errMsg == "")
 		duration := ui.FormatDuration(elapsed)
 		if errMsg == "" {
@@ -308,8 +337,6 @@ func runSerialInstallWithProgress(pkgs []string, progress *ui.StickyProgress) []
 }
 
 func installCaskWithProgress(pkg string, progress *ui.StickyProgress) string {
-	progress.PauseForInteractive()
-
 	cmd := brewInstallCmd("install", "--cask", pkg)
 	tty, opened := system.OpenTTY()
 	if opened {
@@ -318,11 +345,7 @@ func installCaskWithProgress(pkg string, progress *ui.StickyProgress) string {
 	cmd.Stdin = tty
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-
-	progress.ResumeAfterInteractive()
-
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		return "install failed"
 	}
 	return ""

--- a/internal/brew/brew_install.go
+++ b/internal/brew/brew_install.go
@@ -204,24 +204,32 @@ func installCasksWithProgress(pkgs []string, progress *ui.StickyProgress) (insta
 		progress.PrintLine("  Installing %s...", pkg)
 
 		// Start tracker for this cask (skip if size unknown — no bar, just spinner).
+		// trackerDone closes only after the goroutine has emitted its final
+		// reading, so we never let a stale byte value bleed into the next cask.
 		var trackerCancel context.CancelFunc
+		var trackerDone chan struct{}
 		if size, ok := sizes[pkg]; ok && size > 0 {
 			tracker, err := NewCacheTracker(pkg)
 			if err == nil {
 				ctx, cancel := context.WithCancel(context.Background())
 				trackerCancel = cancel
-				go tracker.Run(ctx, func(b int64) {
-					progress.SetCurrentBytes(b, size)
-				})
+				trackerDone = make(chan struct{})
+				go func() {
+					defer close(trackerDone)
+					tracker.Run(ctx, func(b int64) {
+						progress.SetCurrentBytes(b, size)
+					})
+				}()
 			}
 		}
 
 		start := time.Now()
-		errMsg := installCaskWithProgress(pkg, progress)
+		errMsg := installCaskWithProgress(pkg)
 		elapsed := time.Since(start)
 
 		if trackerCancel != nil {
 			trackerCancel()
+			<-trackerDone
 		}
 
 		progress.IncrementWithStatus(errMsg == "")
@@ -336,7 +344,7 @@ func runSerialInstallWithProgress(pkgs []string, progress *ui.StickyProgress) []
 	return failed
 }
 
-func installCaskWithProgress(pkg string, progress *ui.StickyProgress) string {
+func installCaskWithProgress(pkg string) string {
 	cmd := brewInstallCmd("install", "--cask", pkg)
 	tty, opened := system.OpenTTY()
 	if opened {

--- a/internal/brew/cache.go
+++ b/internal/brew/cache.go
@@ -1,0 +1,89 @@
+package brew
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CacheTracker polls the brew downloads directory for the partial file
+// matching a cask name and reports its current size.
+type CacheTracker struct {
+	cacheDir string
+	match    string
+	interval time.Duration
+}
+
+// NewCacheTracker builds a tracker for the given cask. cacheDir is resolved
+// via `brew --cache --cask <name>` (parent dir).
+func NewCacheTracker(caskName string) (*CacheTracker, error) {
+	dir, err := resolveBrewCacheDir(caskName)
+	if err != nil {
+		return nil, err
+	}
+	return &CacheTracker{
+		cacheDir: dir,
+		match:    caskName,
+		interval: 500 * time.Millisecond,
+	}, nil
+}
+
+// Run polls every interval and invokes onProgress with the current matched
+// file size. Stops when ctx is done. Always emits at least one final value
+// before returning.
+func (t *CacheTracker) Run(ctx context.Context, onProgress func(bytes int64)) {
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	emit := func() { onProgress(t.currentSize()) }
+	emit()
+	for {
+		select {
+		case <-ctx.Done():
+			emit() // final reading
+			return
+		case <-ticker.C:
+			emit()
+		}
+	}
+}
+
+func (t *CacheTracker) currentSize() int64 {
+	entries, err := os.ReadDir(t.cacheDir)
+	if err != nil {
+		return 0
+	}
+	var largest int64
+	needle := strings.ToLower(t.match)
+	for _, e := range entries {
+		name := strings.ToLower(e.Name())
+		if !strings.Contains(name, needle) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.Size() > largest {
+			largest = info.Size()
+		}
+	}
+	return largest
+}
+
+// resolveBrewCacheDir asks brew where it stores downloads for the given cask
+// and returns the containing directory. (`brew --cache --cask X` returns the
+// expected full path; we use its parent so we can glob multiple candidates.)
+func resolveBrewCacheDir(caskName string) (string, error) {
+	out, err := currentRunner().Output("--cache", "--cask", caskName)
+	if err != nil {
+		return "", err
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		return "", os.ErrNotExist
+	}
+	return filepath.Dir(path), nil
+}

--- a/internal/brew/cache_test.go
+++ b/internal/brew/cache_test.go
@@ -1,0 +1,77 @@
+package brew
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheTrackerReportsFileSize(t *testing.T) {
+	dir := t.TempDir()
+	caskFile := filepath.Join(dir, "abc123--Docker.dmg")
+	require.NoError(t, os.WriteFile(caskFile, make([]byte, 1024), 0o644))
+
+	tracker := &CacheTracker{
+		cacheDir: dir,
+		match:    "Docker",
+		interval: 10 * time.Millisecond,
+	}
+
+	var observed atomic.Int64
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tracker.Run(ctx, func(bytes int64) { observed.Store(bytes) })
+	}()
+	wg.Wait()
+	assert.EqualValues(t, 1024, observed.Load())
+}
+
+func TestCacheTrackerPicksLargestMatchingFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "old--Docker.dmg"), make([]byte, 100), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new--Docker.dmg.incomplete"), make([]byte, 5000), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "unrelated--Rectangle.dmg"), make([]byte, 9999), 0o644))
+
+	tracker := &CacheTracker{
+		cacheDir: dir,
+		match:    "Docker",
+		interval: 10 * time.Millisecond,
+	}
+
+	var observed atomic.Int64
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	tracker.Run(ctx, func(bytes int64) { observed.Store(bytes) })
+	// Picks the largest matching file (the .incomplete download).
+	assert.EqualValues(t, 5000, observed.Load())
+}
+
+func TestCacheTrackerNoMatchReportsZero(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "unrelated--Other.dmg"), make([]byte, 100), 0o644))
+
+	tracker := &CacheTracker{
+		cacheDir: dir,
+		match:    "Docker",
+		interval: 10 * time.Millisecond,
+	}
+
+	var observed atomic.Int64
+	observed.Store(-1) // sentinel
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	tracker.Run(ctx, func(bytes int64) { observed.Store(bytes) })
+	// No matching file → callback receives 0.
+	assert.EqualValues(t, 0, observed.Load())
+}

--- a/internal/brew/install_progress_behavior_test.go
+++ b/internal/brew/install_progress_behavior_test.go
@@ -58,6 +58,15 @@ fi
 if [ "$1" = "list" ] && [ "$2" = "--cask" ]; then
   exit 0
 fi
+if [ "$1" = "info" ] && [ "$3" = "--cask" ]; then
+  # Cask size pre-fetch — return JSON with token + URL so FetchCaskSizes
+  # has something to parse. The URL points nowhere reachable; HEAD will
+  # fail and size stays 0, which is fine for this test.
+  cat <<'EOF'
+[{"token":"firefox","url":"http://127.0.0.1:1/firefox.dmg"}]
+EOF
+  exit 0
+fi
 if [ "$1" = "info" ]; then
   shift 2
   for arg in "$@"; do
@@ -95,16 +104,22 @@ exit 0
 	logContent, err := os.ReadFile(logPath)
 	require.NoError(t, err)
 
-	var infoLines []string
+	var formulaInfo, caskInfo []string
 	for _, line := range strings.Split(strings.TrimSpace(string(logContent)), "\n") {
-		if strings.HasPrefix(line, "info --json") {
-			infoLines = append(infoLines, line)
+		switch {
+		case strings.HasPrefix(line, "info --json --cask"):
+			caskInfo = append(caskInfo, line)
+		case strings.HasPrefix(line, "info --json"):
+			formulaInfo = append(formulaInfo, line)
 		}
 	}
 
-	require.Len(t, infoLines, 1)
-	assert.Equal(t, "info --json postgresql kubectl", infoLines[0])
-	assert.NotContains(t, infoLines[0], "firefox")
+	require.Len(t, formulaInfo, 1, "formula alias resolution should be a single batch")
+	assert.Equal(t, "info --json postgresql kubectl", formulaInfo[0])
+	assert.NotContains(t, formulaInfo[0], "firefox")
+
+	require.Len(t, caskInfo, 1, "cask size pre-fetch should be a single batch")
+	assert.Equal(t, "info --json --cask firefox", caskInfo[0])
 }
 
 func TestInstallWithProgress_RetrySuccessTracksCanonicalNames(t *testing.T) {

--- a/internal/brew/sizecheck.go
+++ b/internal/brew/sizecheck.go
@@ -1,0 +1,71 @@
+package brew
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/openbootdotdev/openboot/internal/httputil"
+)
+
+// caskInfo is the subset of `brew info --json --cask` we care about.
+type caskInfo struct {
+	Token string `json:"token"`
+	URL   string `json:"url"`
+}
+
+// FetchCaskSizes resolves each cask's download URL via `brew info --json
+// --cask`, then issues HEAD requests in parallel to read Content-Length.
+// Returns a map[caskName]bytes; missing entries default to 0 (caller treats
+// as "size unknown — no live bytes display").
+func FetchCaskSizes(ctx context.Context, casks []string) map[string]int64 {
+	result := make(map[string]int64, len(casks))
+	if len(casks) == 0 {
+		return result
+	}
+
+	args := append([]string{"info", "--json", "--cask"}, casks...)
+	output, err := currentRunner().Output(args...)
+	if err != nil {
+		return result
+	}
+
+	var entries []caskInfo
+	if err := json.Unmarshal(output, &entries); err != nil {
+		return result
+	}
+
+	client := &http.Client{Timeout: 8 * time.Second}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, e := range entries {
+		if e.URL == "" {
+			result[e.Token] = 0
+			continue
+		}
+		wg.Add(1)
+		go func(token, url string) {
+			defer wg.Done()
+			size := headContentLength(ctx, client, url)
+			mu.Lock()
+			result[token] = size
+			mu.Unlock()
+		}(e.Token, e.URL)
+	}
+	wg.Wait()
+	return result
+}
+
+func headContentLength(ctx context.Context, client *http.Client, url string) int64 {
+	resp, err := httputil.Head(ctx, client, url)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort body close
+	if resp.ContentLength < 0 {
+		return 0
+	}
+	return resp.ContentLength
+}

--- a/internal/brew/sizecheck_test.go
+++ b/internal/brew/sizecheck_test.go
@@ -1,0 +1,49 @@
+package brew
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchCaskSizesReturnsBytesPerCask(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/docker.dmg":
+			w.Header().Set("Content-Length", "450000000")
+		case "/rectangle.dmg":
+			w.Header().Set("Content-Length", "12000000")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	withFakeBrew(t, func(args []string) ([]byte, error) {
+		// Expect: brew info --json --cask docker rectangle
+		if len(args) >= 3 && args[0] == "info" && args[1] == "--json" && args[2] == "--cask" {
+			return []byte(fmt.Sprintf(
+				`[{"token":"docker","url":"%s/docker.dmg"},{"token":"rectangle","url":"%s/rectangle.dmg"}]`,
+				srv.URL, srv.URL,
+			)), nil
+		}
+		return nil, fmt.Errorf("unexpected args: %v", args)
+	})
+
+	sizes := FetchCaskSizes(context.Background(), []string{"docker", "rectangle"})
+	assert.Equal(t, int64(450000000), sizes["docker"])
+	assert.Equal(t, int64(12000000), sizes["rectangle"])
+}
+
+func TestFetchCaskSizesSkipsHeadFailures(t *testing.T) {
+	withFakeBrew(t, func(args []string) ([]byte, error) {
+		return []byte(`[{"token":"broken","url":"http://127.0.0.1:1/nope"}]`), nil
+	})
+
+	sizes := FetchCaskSizes(context.Background(), []string{"broken"})
+	// Failed HEAD leaves entry at 0 (caller treats as "unknown size").
+	assert.Equal(t, int64(0), sizes["broken"])
+}

--- a/internal/httputil/head.go
+++ b/internal/httputil/head.go
@@ -1,0 +1,17 @@
+package httputil
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// Head issues a HEAD request and routes it through Do so 429 + Retry-After
+// are handled uniformly. The caller must close the response body.
+func Head(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build HEAD request: %w", err)
+	}
+	return Do(client, req)
+}

--- a/internal/httputil/head_test.go
+++ b/internal/httputil/head_test.go
@@ -1,0 +1,43 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadReturnsContentLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "HEAD", r.Method)
+		w.Header().Set("Content-Length", "12345")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := Head(context.Background(), http.DefaultClient, srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, int64(12345), resp.ContentLength)
+}
+
+func TestHeadFollowsRedirect(t *testing.T) {
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "99")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer final.Close()
+
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, final.URL, http.StatusFound)
+	}))
+	defer redirect.Close()
+
+	resp, err := Head(context.Background(), http.DefaultClient, redirect.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, int64(99), resp.ContentLength)
+}

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -186,23 +186,6 @@ func (sp *StickyProgress) renderInline() {
 // formatLines returns the two strings to render in the scroll region:
 // row 1 = data + bar, row 2 = divider line.
 func (sp *StickyProgress) formatLines() []string {
-	pct := float64(0)
-	if sp.total > 0 {
-		pct = float64(sp.completed) / float64(sp.total)
-	}
-	cols := 80
-	if sp.region != nil {
-		cols = sp.region.Cols()
-	}
-	barWidth := cols - 40
-	if barWidth < 20 {
-		barWidth = 20
-	}
-	filled := int(pct * float64(barWidth))
-	empty := barWidth - filled
-	bar := progressBarStyle.Render(strings.Repeat("█", filled)) +
-		progressBgStyle.Render(strings.Repeat("░", empty))
-
 	var head string
 	switch sp.phase {
 	case PhaseCask:
@@ -210,6 +193,31 @@ func (sp *StickyProgress) formatLines() []string {
 	default:
 		head = sp.formatFormulaHead()
 	}
+
+	cols := 80
+	if sp.region != nil {
+		cols = sp.region.Cols()
+	}
+
+	// barWidth is whatever's left after head + " " + bar + " 100%" suffix.
+	// Clamp [minBarWidth, defaultBarWidth] so the bar stays readable on
+	// narrow terminals and doesn't dominate wide ones.
+	barWidth := cols - len(head) - 6
+	if barWidth < minBarWidth {
+		barWidth = minBarWidth
+	}
+	if barWidth > defaultBarWidth {
+		barWidth = defaultBarWidth
+	}
+
+	pct := float64(0)
+	if sp.total > 0 {
+		pct = float64(sp.completed) / float64(sp.total)
+	}
+	filled := int(pct * float64(barWidth))
+	empty := barWidth - filled
+	bar := progressBarStyle.Render(strings.Repeat("█", filled)) +
+		progressBgStyle.Render(strings.Repeat("░", empty))
 
 	line1 := fmt.Sprintf("%s %s %3d%%", head, bar, int(pct*100))
 	line2 := strings.Repeat("─", cols)
@@ -366,7 +374,7 @@ func (sp *StickyProgress) PrintLine(format string, args ...interface{}) {
 
 // Deprecated: scroll region keeps the bar visible during interactive
 // subprocess output, so callers no longer need to pause. Will be removed
-// in the brew_install.go wiring task.
+// once brew_install.go no longer calls these stubs.
 func (sp *StickyProgress) PauseForInteractive() {}
 
 // Deprecated: see PauseForInteractive.

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -37,6 +37,14 @@ var (
 			Foreground(lipgloss.Color("#666"))
 )
 
+// Phase tracks whether the progress bar is in formula or cask mode.
+type Phase int
+
+const (
+	PhaseFormula Phase = iota
+	PhaseCask
+)
+
 type StickyProgress struct {
 	total      int
 	completed  int
@@ -53,6 +61,20 @@ type StickyProgress struct {
 	succeeded  int
 	failed     int
 	skipped    int
+
+	// Phase tracks whether we're installing formulae or casks. Cask phase
+	// switches to byte-based ETA when bytes are available.
+	phase Phase
+
+	// Cask-only: real-time download tracking.
+	currentBytes int64
+	totalBytes   int64
+	speed        float64 // bytes/sec, EMA
+	lastBytes    int64
+	lastTime     time.Time
+
+	// Scroll region rendering (nil when terminal doesn't support it).
+	region *ScrollRegion
 }
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -91,6 +113,10 @@ func (sp *StickyProgress) Start() {
 	sp.mu.Lock()
 	sp.active = true
 	sp.startTime = time.Now()
+	if IsScrollRegionSupported() {
+		sp.region = NewScrollRegion(2)
+		sp.region.Start()
+	}
 	sp.mu.Unlock()
 
 	signal.Stop(sp.sigCh)
@@ -119,6 +145,16 @@ func (sp *StickyProgress) Start() {
 }
 
 func (sp *StickyProgress) render() {
+	if sp.region != nil {
+		sp.region.DrawTop(sp.formatLines())
+		return
+	}
+	sp.renderInline()
+}
+
+// renderInline is the existing inline-line rendering used when scroll region
+// is unavailable.
+func (sp *StickyProgress) renderInline() {
 	pct := float64(0)
 	if sp.total > 0 {
 		pct = float64(sp.completed) / float64(sp.total)
@@ -145,6 +181,137 @@ func (sp *StickyProgress) render() {
 		progressTextStyle.Render(status),
 		etaStyle.Render(eta),
 		currentPkgStyle.Render(pkgDisplay))
+}
+
+// formatLines returns the two strings to render in the scroll region:
+// row 1 = data + bar, row 2 = divider line.
+func (sp *StickyProgress) formatLines() []string {
+	pct := float64(0)
+	if sp.total > 0 {
+		pct = float64(sp.completed) / float64(sp.total)
+	}
+	cols := 80
+	if sp.region != nil {
+		cols = sp.region.Cols()
+	}
+	barWidth := cols - 40
+	if barWidth < 20 {
+		barWidth = 20
+	}
+	filled := int(pct * float64(barWidth))
+	empty := barWidth - filled
+	bar := progressBarStyle.Render(strings.Repeat("█", filled)) +
+		progressBgStyle.Render(strings.Repeat("░", empty))
+
+	var head string
+	switch sp.phase {
+	case PhaseCask:
+		head = sp.formatCaskHead()
+	default:
+		head = sp.formatFormulaHead()
+	}
+
+	line1 := fmt.Sprintf("%s %s %3d%%", head, bar, int(pct*100))
+	line2 := strings.Repeat("─", cols)
+	return []string{line1, line2}
+}
+
+func (sp *StickyProgress) formatFormulaHead() string {
+	pkg := truncate(sp.currentPkg, 24)
+	return fmt.Sprintf("[%d/%d] %-24s", sp.completed, sp.total, pkg)
+}
+
+func (sp *StickyProgress) formatCaskHead() string {
+	pkg := truncate(sp.currentPkg, 18)
+	bytes := "—"
+	speed := "—"
+	if sp.totalBytes > 0 {
+		bytes = fmt.Sprintf("%s/%s", humanBytes(sp.currentBytes), humanBytes(sp.totalBytes))
+	}
+	if sp.speed > 0 {
+		speed = fmt.Sprintf("%s/s", humanBytes(int64(sp.speed)))
+	}
+	eta := sp.estimateCurrentCaskETA()
+	if eta == "" {
+		eta = "—"
+	}
+	return fmt.Sprintf("[%d/%d] %-18s %s · %s · %s", sp.completed, sp.total, pkg, bytes, speed, eta)
+}
+
+func humanBytes(n int64) string {
+	switch {
+	case n >= 1<<30:
+		return fmt.Sprintf("%.1fG", float64(n)/(1<<30))
+	case n >= 1<<20:
+		return fmt.Sprintf("%dM", n/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%dK", n/(1<<10))
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}
+
+// SetPhase switches between formula and cask data displays. Per-cask byte
+// state is cleared on each transition.
+func (sp *StickyProgress) SetPhase(p Phase) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.phase = p
+	sp.currentBytes = 0
+	sp.totalBytes = 0
+	sp.speed = 0
+	sp.lastBytes = 0
+	sp.lastTime = time.Time{}
+}
+
+// SetCurrentBytes records progress for the currently-installing cask. The
+// total comes from a pre-flight HEAD on the cask URL; current comes from
+// polling the brew cache directory. Updates the EMA speed estimate.
+func (sp *StickyProgress) SetCurrentBytes(current, total int64) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.observeBytesAt(current, time.Now())
+	sp.totalBytes = total
+}
+
+// observeBytesAt is the testable inner loop of SetCurrentBytes (lets tests
+// inject a clock).
+func (sp *StickyProgress) observeBytesAt(current int64, now time.Time) {
+	if !sp.lastTime.IsZero() && current > sp.lastBytes {
+		dt := now.Sub(sp.lastTime).Seconds()
+		if dt > 0 {
+			instant := float64(current-sp.lastBytes) / dt
+			if sp.speed == 0 {
+				sp.speed = instant
+			} else {
+				// EMA with alpha=0.3 (favors recent samples, smooths jitter).
+				sp.speed = 0.3*instant + 0.7*sp.speed
+			}
+		}
+	}
+	sp.currentBytes = current
+	sp.lastBytes = current
+	sp.lastTime = now
+}
+
+func (sp *StickyProgress) estimateCurrentCaskETA() string {
+	if sp.speed <= 0 || sp.totalBytes <= 0 || sp.currentBytes >= sp.totalBytes {
+		if sp.totalBytes > 0 && sp.currentBytes < sp.totalBytes {
+			return "estimating..."
+		}
+		return ""
+	}
+	remaining := sp.totalBytes - sp.currentBytes
+	secs := float64(remaining) / sp.speed
+	if secs < 60 {
+		return fmt.Sprintf("~%ds", int(secs))
+	}
+	mins := int(secs) / 60
+	rem := int(secs) % 60
+	if rem == 0 {
+		return fmt.Sprintf("~%dm", mins)
+	}
+	return fmt.Sprintf("~%dm%ds", mins, rem)
 }
 
 func (sp *StickyProgress) SetCurrent(pkgName string) {
@@ -197,19 +364,13 @@ func (sp *StickyProgress) PrintLine(format string, args ...interface{}) {
 	}
 }
 
-func (sp *StickyProgress) PauseForInteractive() {
-	sp.mu.Lock()
-	defer sp.mu.Unlock()
-	sp.active = false
-	fmt.Printf("\r\033[K")
-}
+// Deprecated: scroll region keeps the bar visible during interactive
+// subprocess output, so callers no longer need to pause. Will be removed
+// in the brew_install.go wiring task.
+func (sp *StickyProgress) PauseForInteractive() {}
 
-func (sp *StickyProgress) ResumeAfterInteractive() {
-	sp.mu.Lock()
-	defer sp.mu.Unlock()
-	sp.active = true
-	sp.render()
-}
+// Deprecated: see PauseForInteractive.
+func (sp *StickyProgress) ResumeAfterInteractive() {}
 
 func (sp *StickyProgress) Finish() {
 	signal.Stop(sp.sigCh)
@@ -217,7 +378,12 @@ func (sp *StickyProgress) Finish() {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 	sp.active = false
-	fmt.Printf("\r\033[K")
+	if sp.region != nil {
+		sp.region.Stop()
+		sp.region = nil
+	} else {
+		fmt.Printf("\r\033[K")
+	}
 
 	elapsed := time.Since(sp.startTime)
 

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -200,9 +200,10 @@ func (sp *StickyProgress) formatLines() []string {
 	}
 
 	// barWidth is whatever's left after head + " " + bar + " 100%" suffix.
-	// Clamp [minBarWidth, defaultBarWidth] so the bar stays readable on
-	// narrow terminals and doesn't dominate wide ones.
-	barWidth := cols - len(head) - 6
+	// Use visual width (not byte length) so multi-byte runes like "—" don't
+	// over-count and shrink the bar. Clamp [minBarWidth, defaultBarWidth] so
+	// the bar stays readable on narrow terminals and doesn't dominate wide ones.
+	barWidth := cols - lipgloss.Width(head) - 6
 	if barWidth < minBarWidth {
 		barWidth = minBarWidth
 	}

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -372,14 +372,6 @@ func (sp *StickyProgress) PrintLine(format string, args ...interface{}) {
 	}
 }
 
-// Deprecated: scroll region keeps the bar visible during interactive
-// subprocess output, so callers no longer need to pause. Will be removed
-// once brew_install.go no longer calls these stubs.
-func (sp *StickyProgress) PauseForInteractive() {}
-
-// Deprecated: see PauseForInteractive.
-func (sp *StickyProgress) ResumeAfterInteractive() {}
-
 func (sp *StickyProgress) Finish() {
 	signal.Stop(sp.sigCh)
 	sp.closeOnce.Do(func() { close(sp.stopCh) })

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -143,8 +143,23 @@ func TestStickyProgressSetCurrentDoesNotPanic(t *testing.T) {
 
 func TestStickyProgressSetPhase(t *testing.T) {
 	sp := NewStickyProgress(10)
+	// Seed some byte state from a "previous" cask.
+	sp.currentBytes = 999
+	sp.totalBytes = 9999
+	sp.speed = 1234
+	sp.lastBytes = 999
+	sp.lastTime = time.Unix(42, 0)
+
 	sp.SetPhase(PhaseCask)
 	assert.Equal(t, PhaseCask, sp.phase)
+
+	// SetPhase must reset all per-cask byte state so the next cask
+	// starts clean (no stale bytes bleeding into the bar).
+	assert.EqualValues(t, 0, sp.currentBytes)
+	assert.EqualValues(t, 0, sp.totalBytes)
+	assert.InDelta(t, 0, sp.speed, 0.01)
+	assert.EqualValues(t, 0, sp.lastBytes)
+	assert.True(t, sp.lastTime.IsZero())
 }
 
 func TestStickyProgressSetCurrentBytes(t *testing.T) {

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -190,3 +190,15 @@ func TestStickyProgressEstimatingPlaceholder(t *testing.T) {
 	eta := sp.estimateCurrentCaskETA()
 	assert.Equal(t, "estimating...", eta)
 }
+
+func TestStickyProgressFallsBackWhenScrollRegionUnsupported(t *testing.T) {
+	t.Setenv("TERM", "dumb")
+	sp := NewStickyProgress(3)
+	sp.Start()
+	defer sp.Finish()
+	// Region should NOT have been attached.
+	sp.mu.Lock()
+	hasRegion := sp.region != nil
+	sp.mu.Unlock()
+	assert.False(t, hasRegion, "scroll region should be disabled on dumb TERM")
+}

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -141,12 +141,48 @@ func TestStickyProgressSetCurrentDoesNotPanic(t *testing.T) {
 	})
 }
 
-func TestStickyProgressPauseResume(t *testing.T) {
-	sp := NewStickyProgress(5)
-	sp.mu.Lock()
-	sp.active = true
-	sp.mu.Unlock()
+func TestStickyProgressSetPhase(t *testing.T) {
+	sp := NewStickyProgress(10)
+	sp.SetPhase(PhaseCask)
+	assert.Equal(t, PhaseCask, sp.phase)
+}
 
-	sp.PauseForInteractive()
-	assert.False(t, sp.active)
+func TestStickyProgressSetCurrentBytes(t *testing.T) {
+	sp := NewStickyProgress(10)
+	sp.SetPhase(PhaseCask)
+	sp.SetCurrentBytes(50_000_000, 200_000_000)
+	assert.EqualValues(t, 50_000_000, sp.currentBytes)
+	assert.EqualValues(t, 200_000_000, sp.totalBytes)
+}
+
+func TestStickyProgressSpeedEMA(t *testing.T) {
+	sp := NewStickyProgress(10)
+	sp.SetPhase(PhaseCask)
+	// First sample: no speed yet (need two points).
+	sp.observeBytesAt(1_000_000, time.Unix(0, 0))
+	assert.InDelta(t, 0, sp.speed, 0.01)
+	// Second sample one second later: 1 MB more = 1 MB/s.
+	sp.observeBytesAt(2_000_000, time.Unix(1, 0))
+	assert.InDelta(t, 1_000_000, sp.speed, 1.0)
+}
+
+func TestStickyProgressBytesETAUsesSpeed(t *testing.T) {
+	sp := NewStickyProgress(10)
+	sp.SetPhase(PhaseCask)
+	sp.currentBytes = 100_000_000
+	sp.totalBytes = 500_000_000
+	sp.speed = 10_000_000 // 10 MB/s
+	eta := sp.estimateCurrentCaskETA()
+	// 400MB / 10 MB/s = 40s.
+	assert.Equal(t, "~40s", eta)
+}
+
+func TestStickyProgressEstimatingPlaceholder(t *testing.T) {
+	sp := NewStickyProgress(10)
+	sp.SetPhase(PhaseCask)
+	sp.currentBytes = 0
+	sp.totalBytes = 100_000_000
+	sp.speed = 0
+	eta := sp.estimateCurrentCaskETA()
+	assert.Equal(t, "estimating...", eta)
 }

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -161,9 +161,13 @@ func TestStickyProgressSpeedEMA(t *testing.T) {
 	// First sample: no speed yet (need two points).
 	sp.observeBytesAt(1_000_000, time.Unix(0, 0))
 	assert.InDelta(t, 0, sp.speed, 0.01)
-	// Second sample one second later: 1 MB more = 1 MB/s.
+	// Second sample one second later: 1 MB more = 1 MB/s, sets speed directly.
 	sp.observeBytesAt(2_000_000, time.Unix(1, 0))
 	assert.InDelta(t, 1_000_000, sp.speed, 1.0)
+	// Third sample: 500 KB more in 1s = 500 K/s instantaneous.
+	// EMA blends: 0.3*500_000 + 0.7*1_000_000 = 850_000.
+	sp.observeBytesAt(2_500_000, time.Unix(2, 0))
+	assert.InDelta(t, 850_000, sp.speed, 1.0)
 }
 
 func TestStickyProgressBytesETAUsesSpeed(t *testing.T) {

--- a/internal/ui/scrollregion.go
+++ b/internal/ui/scrollregion.go
@@ -62,19 +62,26 @@ func (r *ScrollRegion) DrawTop(lines []string) {
 // Cols returns the current terminal width.
 func (r *ScrollRegion) Cols() int { return r.cols }
 
+// write is the internal sink for ANSI control sequences. Terminal writes
+// are best-effort — a failed write to stdout is not recoverable and
+// silently dropping the error matches every other UI helper in this file.
+func (r *ScrollRegion) write(format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(r.w, format, args...)
+}
+
 func (r *ScrollRegion) reserve() {
 	// Hide cursor, set scroll region from row (reserved+1) to last row,
 	// then move cursor into the scroll region.
-	fmt.Fprintf(r.w, "\x1b[?25l")
-	fmt.Fprintf(r.w, "\x1b[%d;%dr", r.reserved+1, r.rows)
-	fmt.Fprintf(r.w, "\x1b[%d;1H", r.reserved+1)
+	r.write("\x1b[?25l")
+	r.write("\x1b[%d;%dr", r.reserved+1, r.rows)
+	r.write("\x1b[%d;1H", r.reserved+1)
 }
 
 func (r *ScrollRegion) reset() {
 	// Reset scroll region, show cursor, move cursor to the bottom row.
-	fmt.Fprintf(r.w, "\x1b[r")
-	fmt.Fprintf(r.w, "\x1b[?25h")
-	fmt.Fprintf(r.w, "\x1b[%d;1H", r.rows)
+	r.write("\x1b[r")
+	r.write("\x1b[?25h")
+	r.write("\x1b[%d;1H", r.rows)
 }
 
 func (r *ScrollRegion) drawTop(lines []string) {
@@ -82,11 +89,11 @@ func (r *ScrollRegion) drawTop(lines []string) {
 		panic(fmt.Sprintf("scrollregion: %d lines exceed reserved %d", len(lines), r.reserved))
 	}
 	// DEC save cursor, draw each reserved row from top, restore.
-	fmt.Fprintf(r.w, "\x1b7")
+	r.write("\x1b7")
 	for i, line := range lines {
-		fmt.Fprintf(r.w, "\x1b[%d;1H\x1b[2K%s", i+1, line)
+		r.write("\x1b[%d;1H\x1b[2K%s", i+1, line)
 	}
-	fmt.Fprintf(r.w, "\x1b8")
+	r.write("\x1b8")
 }
 
 // IsScrollRegionSupported reports whether the current terminal can use the
@@ -94,7 +101,7 @@ func (r *ScrollRegion) drawTop(lines []string) {
 // stdout is not a TTY, or the terminal is too short.
 func IsScrollRegionSupported() bool {
 	_, h := terminalSize()
-	return isScrollRegionSupportedFor(os.Getenv("TERM"), h, term.IsTerminal(int(os.Stdout.Fd())))
+	return isScrollRegionSupportedFor(os.Getenv("TERM"), h, term.IsTerminal(int(os.Stdout.Fd()))) //nolint:gosec // os.Stdout.Fd() returns a valid file descriptor; uintptr fits in int on all supported platforms
 }
 
 func isScrollRegionSupportedFor(termEnv string, rows int, isTTY bool) bool {
@@ -111,7 +118,7 @@ func isScrollRegionSupportedFor(termEnv string, rows int, isTTY bool) bool {
 }
 
 func terminalSize() (cols, rows int) {
-	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	w, h, err := term.GetSize(int(os.Stdout.Fd())) //nolint:gosec // os.Stdout.Fd() returns a valid file descriptor; uintptr fits in int on all supported platforms
 	if err != nil || w <= 0 || h <= 0 {
 		return 80, 24
 	}

--- a/internal/ui/scrollregion.go
+++ b/internal/ui/scrollregion.go
@@ -1,0 +1,119 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// minRowsForRegion is the smallest terminal height where reserving 2 sticky
+// rows still leaves a usable scroll region. Tiny terminals fall back to the
+// non-region path.
+const minRowsForRegion = 6
+
+// ScrollRegion owns the ANSI plumbing for reserving the top N rows as a
+// "frozen" region while output below scrolls. Use IsScrollRegionSupported to
+// check before enabling; on unsupported terminals, callers should render
+// inline instead.
+type ScrollRegion struct {
+	w        io.Writer
+	rows     int
+	cols     int
+	reserved int
+	active   bool
+}
+
+// NewScrollRegion constructs a scroll region for stdout with the given number
+// of reserved top rows. Caller must invoke Start before drawing and Stop on
+// teardown (defer / signal handler).
+func NewScrollRegion(reserved int) *ScrollRegion {
+	w, h := terminalSize()
+	return &ScrollRegion{
+		w:        os.Stdout,
+		rows:     h,
+		cols:     w,
+		reserved: reserved,
+	}
+}
+
+// Start reserves the region and hides the cursor.
+func (r *ScrollRegion) Start() {
+	r.reserve()
+	r.active = true
+}
+
+// Stop resets the scroll region and shows the cursor. Idempotent.
+func (r *ScrollRegion) Stop() {
+	if !r.active {
+		return
+	}
+	r.reset()
+	r.active = false
+}
+
+// DrawTop writes lines to the reserved region without disturbing the cursor
+// in the scrolling area. len(lines) must be <= reserved.
+func (r *ScrollRegion) DrawTop(lines []string) {
+	r.drawTop(lines)
+}
+
+// Cols returns the current terminal width.
+func (r *ScrollRegion) Cols() int { return r.cols }
+
+func (r *ScrollRegion) reserve() {
+	// Hide cursor, set scroll region from row (reserved+1) to last row,
+	// then move cursor into the scroll region.
+	fmt.Fprintf(r.w, "\x1b[?25l")
+	fmt.Fprintf(r.w, "\x1b[%d;%dr", r.reserved+1, r.rows)
+	fmt.Fprintf(r.w, "\x1b[%d;1H", r.reserved+1)
+}
+
+func (r *ScrollRegion) reset() {
+	// Reset scroll region, show cursor, move cursor to the bottom row.
+	fmt.Fprintf(r.w, "\x1b[r")
+	fmt.Fprintf(r.w, "\x1b[?25h")
+	fmt.Fprintf(r.w, "\x1b[%d;1H", r.rows)
+}
+
+func (r *ScrollRegion) drawTop(lines []string) {
+	if len(lines) > r.reserved {
+		panic(fmt.Sprintf("scrollregion: %d lines exceed reserved %d", len(lines), r.reserved))
+	}
+	// DEC save cursor, draw each reserved row from top, restore.
+	fmt.Fprintf(r.w, "\x1b7")
+	for i, line := range lines {
+		fmt.Fprintf(r.w, "\x1b[%d;1H\x1b[2K%s", i+1, line)
+	}
+	fmt.Fprintf(r.w, "\x1b8")
+}
+
+// IsScrollRegionSupported reports whether the current terminal can use the
+// scroll-region rendering path. Falls back to false if TERM is dumb / empty,
+// stdout is not a TTY, or the terminal is too short.
+func IsScrollRegionSupported() bool {
+	_, h := terminalSize()
+	return isScrollRegionSupportedFor(os.Getenv("TERM"), h, term.IsTerminal(int(os.Stdout.Fd())))
+}
+
+func isScrollRegionSupportedFor(termEnv string, rows int, isTTY bool) bool {
+	if !isTTY {
+		return false
+	}
+	if termEnv == "" || termEnv == "dumb" {
+		return false
+	}
+	if rows < minRowsForRegion {
+		return false
+	}
+	return true
+}
+
+func terminalSize() (cols, rows int) {
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w <= 0 || h <= 0 {
+		return 80, 24
+	}
+	return w, h
+}

--- a/internal/ui/scrollregion_test.go
+++ b/internal/ui/scrollregion_test.go
@@ -1,0 +1,80 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsScrollRegionSupported(t *testing.T) {
+	tests := []struct {
+		name     string
+		term     string
+		rows     int
+		expected bool
+	}{
+		{"xterm-ghostty rows OK", "xterm-ghostty", 24, true},
+		{"xterm-256color rows OK", "xterm-256color", 24, true},
+		{"dumb terminal", "dumb", 24, false},
+		{"empty TERM", "", 24, false},
+		{"terminal too short", "xterm-256color", 4, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TERM", tt.term)
+			got := isScrollRegionSupportedFor(tt.term, tt.rows, true)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestIsScrollRegionSupportedNonTTY(t *testing.T) {
+	// Even with good TERM and rows, non-TTY disables.
+	got := isScrollRegionSupportedFor("xterm-256color", 24, false)
+	assert.False(t, got)
+}
+
+func TestScrollRegionReserveEmitsSequence(t *testing.T) {
+	var buf bytes.Buffer
+	r := &ScrollRegion{w: &buf, rows: 24, cols: 80, reserved: 2}
+	r.reserve()
+	// Expected: hide cursor, set scroll region rows 3..24, move cursor into region.
+	assert.Contains(t, buf.String(), "\x1b[?25l")
+	assert.Contains(t, buf.String(), "\x1b[3;24r")
+	assert.Contains(t, buf.String(), "\x1b[3;1H")
+}
+
+func TestScrollRegionResetEmitsSequence(t *testing.T) {
+	var buf bytes.Buffer
+	r := &ScrollRegion{w: &buf, rows: 24, cols: 80, reserved: 2}
+	r.reset()
+	// Expected: reset scroll region, show cursor, move cursor to bottom.
+	assert.Contains(t, buf.String(), "\x1b[r")
+	assert.Contains(t, buf.String(), "\x1b[?25h")
+	assert.Contains(t, buf.String(), "\x1b[24;1H")
+}
+
+func TestScrollRegionDrawTopUsesSaveRestoreCursor(t *testing.T) {
+	var buf bytes.Buffer
+	r := &ScrollRegion{w: &buf, rows: 24, cols: 80, reserved: 2}
+	r.drawTop([]string{"line one", "line two"})
+	out := buf.String()
+	// DEC save (\x1b7) before, DEC restore (\x1b8) after.
+	assert.True(t, len(out) > 0)
+	assert.Contains(t, out, "\x1b7")
+	assert.Contains(t, out, "\x1b8")
+	assert.Contains(t, out, "\x1b[1;1H")
+	assert.Contains(t, out, "\x1b[2;1H")
+	assert.Contains(t, out, "line one")
+	assert.Contains(t, out, "line two")
+}
+
+func TestScrollRegionDrawTopTooManyLinesPanics(t *testing.T) {
+	var buf bytes.Buffer
+	r := &ScrollRegion{w: &buf, rows: 24, cols: 80, reserved: 2}
+	assert.Panics(t, func() {
+		r.drawTop([]string{"a", "b", "c"}) // reserved=2, given 3
+	})
+}

--- a/internal/ui/scrollregion_test.go
+++ b/internal/ui/scrollregion_test.go
@@ -16,6 +16,7 @@ func TestIsScrollRegionSupported(t *testing.T) {
 	}{
 		{"xterm-ghostty rows OK", "xterm-ghostty", 24, true},
 		{"xterm-256color rows OK", "xterm-256color", 24, true},
+		{"terminal exactly at threshold", "xterm-256color", 6, true},
 		{"dumb terminal", "dumb", 24, false},
 		{"empty TERM", "", 24, false},
 		{"terminal too short", "xterm-256color", 4, false},
@@ -23,7 +24,6 @@ func TestIsScrollRegionSupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("TERM", tt.term)
 			got := isScrollRegionSupportedFor(tt.term, tt.rows, true)
 			assert.Equal(t, tt.expected, got)
 		})
@@ -62,7 +62,6 @@ func TestScrollRegionDrawTopUsesSaveRestoreCursor(t *testing.T) {
 	r.drawTop([]string{"line one", "line two"})
 	out := buf.String()
 	// DEC save (\x1b7) before, DEC restore (\x1b8) after.
-	assert.True(t, len(out) > 0)
 	assert.Contains(t, out, "\x1b7")
 	assert.Contains(t, out, "\x1b8")
 	assert.Contains(t, out, "\x1b[1;1H")


### PR DESCRIPTION
## Summary

- Add ANSI scroll-region progress UI (`internal/ui/scrollregion.go`) that keeps a 2-row sticky bar at the top of the terminal while brew install output (downloads, license / sudo prompts) scrolls below. Gracefully degrades to the existing inline path when `TERM=dumb` or stdout is not a TTY.
- Extend `StickyProgress` with phase awareness (`PhaseFormula` / `PhaseCask`), per-cask byte tracking, and EMA-smoothed download speed. ETA is byte-based for casks once the first sample lands, shows `estimating...` until then.
- Pre-fetch cask download sizes in parallel via `brew info --json --cask` + `httputil.Head` (new helper routed through `Do` for 429 handling). Poll `brew --cache --cask <name>` directory every 500ms for the partial file's growing size.
- Removes the no-op `PauseForInteractive` / `ResumeAfterInteractive` hack — the scroll region survives interactive prompts, so callers no longer need to pause.

## Why

Before: CLI (formula) installs got a live progress bar with ETA; GUI (cask) installs went silent for minutes at a time because `installCaskWithProgress` paused the bar to hand the terminal over to brew (for sudo + license prompts). Users couldn't tell whether the install was progressing or stuck. After: cask installs show real bytes, speed, and ETA, computed from on-disk file growth rather than parsing brew output — so we never fight brew's stdout.

## Test plan

- [x] L1 (`make test-unit`) green across all packages
- [x] `-race` detector green on `internal/brew` and `internal/ui`
- [x] `archtest` baselines updated for the new line of `brewInstallCmd` after the `context` import
- [x] `httputil.Head` archtest stays green (HTTP construction confined to `internal/httputil`)
- [x] Unit tests for: TERM-fallback, EMA blending, byte ETA, `estimating...` placeholder, `SetPhase` zero-reset, cache tracker (largest-match / no-match), parallel HEAD pre-fetch (happy + failed path)
- [x] Existing `install_progress_behavior_test.go` updated to expect the new `info --json --cask` batch and assert no cross-contamination
- [ ] **Pending: manual smoke test in real Ghostty terminal** — `./openboot install <some-cask>` and verify (a) the top 2 rows stay frozen, (b) brew output scrolls below, (c) sudo / license prompts are still responsive, (d) the bar releases cleanly after install. The ANSI scroll-region trick was validated in isolation with a shell script (`scrollregion_test.sh`) but the end-to-end UX with real brew hasn't been verified by a human yet.

## Architecture notes

Plan + design rationale in `docs/superpowers/plans/2026-05-17-unified-scroll-region-progress.md`. Two earlier attempts at the "show progress during cask install" problem were tried and reverted (`06d8770` captured output, broke license prompts; `92c8d19` reverted it). This PR's approach sidesteps that by **never capturing brew's stdout** — instead, the scroll region keeps the bar visible while brew owns the terminal, and byte progress comes from polling the brew cache directory on disk.

12 commits, each its own self-review + commit. Squash-merge will collapse to one.