### PR TITLE
fix(install): bottom-anchored progress bar + real byte tracking

### DIFF
--- a/internal/archtest/baseline/no-direct-exec.txt
+++ b/internal/archtest/baseline/no-direct-exec.txt
@@ -2,7 +2,7 @@
 # Each line is <file>:<line> of a known existing violation.
 # Regenerate: ARCHTEST_UPDATE_BASELINE=1 go test ./internal/archtest/...
 internal/auth/login.go:191
-internal/brew/brew_install.go:393
+internal/brew/brew_install.go:400
 internal/cli/snapshot.go:21
 internal/diff/compare.go:247
 internal/diff/compare.go:253

--- a/internal/archtest/baseline/no-direct-exec.txt
+++ b/internal/archtest/baseline/no-direct-exec.txt
@@ -2,7 +2,7 @@
 # Each line is <file>:<line> of a known existing violation.
 # Regenerate: ARCHTEST_UPDATE_BASELINE=1 go test ./internal/archtest/...
 internal/auth/login.go:191
-internal/brew/brew_install.go:369
+internal/brew/brew_install.go:393
 internal/cli/snapshot.go:21
 internal/diff/compare.go:247
 internal/diff/compare.go:253

--- a/internal/brew/brew_install.go
+++ b/internal/brew/brew_install.go
@@ -219,6 +219,13 @@ func installCasksWithProgress(pkgs []string, sizes map[string]int64, progress *u
 		progress.SetCurrent(pkg)
 		progress.PrintLine("  Installing %s...", pkg)
 
+		// Seed totalBytes for this cask immediately so the head shows
+		// "0B/<size>" instead of "—" for the ~500ms before the cache
+		// tracker's first poll lands. Casks with unknown size pass 0 and
+		// the head's bytes column stays "—" (correct — we have nothing
+		// to show).
+		progress.SetCurrentBytes(0, sizes[pkg])
+
 		// Start tracker for this cask (skip if size unknown — no bar, just spinner).
 		// trackerDone closes only after the goroutine has emitted its final
 		// reading, so we never let a stale byte value bleed into the next cask.

--- a/internal/brew/brew_install.go
+++ b/internal/brew/brew_install.go
@@ -152,15 +152,35 @@ func InstallWithProgress(cliPkgs, caskPkgs []string, dryRun bool) (installedForm
 		return installedFormulae, installedCasks, preErr
 	}
 
+	// Pre-flight HEAD all download URLs (formula bottles + cask downloads)
+	// upfront so the progress bar can be byte-proportional across the WHOLE
+	// install — formula and cask share one continuous bar instead of two
+	// algorithms with a jump in between. Bounded so a slow CDN can't stall
+	// the install phase. Unknown sizes (HEAD failures) contribute 0 and
+	// simply don't advance the bar for that package.
+	sizeCtx, sizeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	formulaSizes := FetchFormulaSizes(sizeCtx, newCli)
+	caskSizes := FetchCaskSizes(sizeCtx, newCask)
+	sizeCancel()
+
+	var installTotalBytes int64
+	for _, s := range formulaSizes {
+		installTotalBytes += s
+	}
+	for _, s := range caskSizes {
+		installTotalBytes += s
+	}
+
 	progress := ui.NewStickyProgress(len(newCli) + len(newCask))
 	progress.SetSkipped(skipped)
+	progress.SetTotalBytes(installTotalBytes)
 	progress.Start()
 
 	var allFailed []failedJob
 
 	if len(newCli) > 0 {
 		progress.SetPhase(ui.PhaseFormula)
-		failed := runSerialInstallWithProgress(newCli, progress)
+		failed := runSerialInstallWithProgress(newCli, formulaSizes, progress)
 		failedSet := make(map[string]bool, len(failed))
 		for _, f := range failed {
 			failedSet[f.name] = true
@@ -174,7 +194,7 @@ func InstallWithProgress(cliPkgs, caskPkgs []string, dryRun bool) (installedForm
 	}
 
 	if len(newCask) > 0 {
-		caskInstalled, caskFailed := installCasksWithProgress(newCask, progress)
+		caskInstalled, caskFailed := installCasksWithProgress(newCask, caskSizes, progress)
 		installedCasks = append(installedCasks, caskInstalled...)
 		allFailed = append(allFailed, caskFailed...)
 	}
@@ -188,24 +208,12 @@ func InstallWithProgress(cliPkgs, caskPkgs []string, dryRun bool) (installedForm
 	return installedFormulae, installedCasks, nil
 }
 
-// installCasksWithProgress installs cask packages one by one with progress reporting.
-// Returns the successfully installed cask names and any failed jobs.
-func installCasksWithProgress(pkgs []string, progress *ui.StickyProgress) (installed []string, failed []failedJob) {
+// installCasksWithProgress installs cask packages one by one with progress
+// reporting. Sizes are pre-fetched by the caller (InstallWithProgress) so
+// the bar's byte total can span formula + cask phases. Returns successful
+// installs and failed jobs.
+func installCasksWithProgress(pkgs []string, sizes map[string]int64, progress *ui.StickyProgress) (installed []string, failed []failedJob) {
 	progress.SetPhase(ui.PhaseCask)
-
-	// Pre-flight HEAD all cask URLs to learn download sizes. Bounded so a
-	// slow CDN doesn't hold up the whole install phase.
-	sizeCtx, sizeCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	sizes := FetchCaskSizes(sizeCtx, pkgs)
-	sizeCancel()
-
-	// Sum known sizes for byte-proportional bar. Casks with unknown sizes
-	// (HEAD failed) contribute 0 — they advance the count but not the bar.
-	var phaseTotalBytes int64
-	for _, size := range sizes {
-		phaseTotalBytes += size
-	}
-	progress.SetPhaseBytesTotal(phaseTotalBytes)
 
 	for _, pkg := range pkgs {
 		progress.SetCurrent(pkg)
@@ -246,7 +254,7 @@ func installCasksWithProgress(pkgs []string, progress *ui.StickyProgress) (insta
 			// Advance the byte-based bar by this cask's known size. Casks
 			// with unknown sizes (HEAD failed) pass 0 here — they advance the
 			// count but not the bar's byte fill.
-			progress.AddCompletedCaskBytes(sizes[pkg])
+			progress.AddCompletedBytes(sizes[pkg])
 			progress.PrintLine("  %s %s", ui.Green("✔ "+pkg), ui.Cyan("("+duration+")"))
 			installed = append(installed, pkg)
 		} else {
@@ -327,7 +335,7 @@ func handleFailedJobs(failed []failedJob) {
 	}
 }
 
-func runSerialInstallWithProgress(pkgs []string, progress *ui.StickyProgress) []failedJob {
+func runSerialInstallWithProgress(pkgs []string, sizes map[string]int64, progress *ui.StickyProgress) []failedJob {
 	if len(pkgs) == 0 {
 		return nil
 	}
@@ -342,6 +350,10 @@ func runSerialInstallWithProgress(pkgs []string, progress *ui.StickyProgress) []
 		progress.IncrementWithStatus(errMsg == "")
 		duration := ui.FormatDuration(elapsed)
 		if errMsg == "" {
+			// Advance the byte-based bar by this formula's bottle size.
+			// Formulae with unknown sizes pass 0; the bar just doesn't move
+			// for them but the count still advances.
+			progress.AddCompletedBytes(sizes[pkg])
 			progress.PrintLine("  %s %s", ui.Green("✔ "+job.name), ui.Cyan("("+duration+")"))
 			continue
 		}

--- a/internal/brew/brew_install.go
+++ b/internal/brew/brew_install.go
@@ -199,6 +199,14 @@ func installCasksWithProgress(pkgs []string, progress *ui.StickyProgress) (insta
 	sizes := FetchCaskSizes(sizeCtx, pkgs)
 	sizeCancel()
 
+	// Sum known sizes for byte-proportional bar. Casks with unknown sizes
+	// (HEAD failed) contribute 0 — they advance the count but not the bar.
+	var phaseTotalBytes int64
+	for _, size := range sizes {
+		phaseTotalBytes += size
+	}
+	progress.SetPhaseBytesTotal(phaseTotalBytes)
+
 	for _, pkg := range pkgs {
 		progress.SetCurrent(pkg)
 		progress.PrintLine("  Installing %s...", pkg)
@@ -235,6 +243,10 @@ func installCasksWithProgress(pkgs []string, progress *ui.StickyProgress) (insta
 		progress.IncrementWithStatus(errMsg == "")
 		duration := ui.FormatDuration(elapsed)
 		if errMsg == "" {
+			// Advance the byte-based bar by this cask's known size. Casks
+			// with unknown sizes (HEAD failed) pass 0 here — they advance the
+			// count but not the bar's byte fill.
+			progress.AddCompletedCaskBytes(sizes[pkg])
 			progress.PrintLine("  %s %s", ui.Green("✔ "+pkg), ui.Cyan("("+duration+")"))
 			installed = append(installed, pkg)
 		} else {

--- a/internal/brew/install_progress_behavior_test.go
+++ b/internal/brew/install_progress_behavior_test.go
@@ -58,12 +58,12 @@ fi
 if [ "$1" = "list" ] && [ "$2" = "--cask" ]; then
   exit 0
 fi
-if [ "$1" = "info" ] && [ "$3" = "--cask" ]; then
-  # Cask size pre-fetch — return JSON with token + URL so FetchCaskSizes
+if [ "$1" = "info" ] && [ "$2" = "--json=v2" ] && [ "$3" = "--cask" ]; then
+  # Cask size pre-fetch — return v2 envelope with token + URL so FetchCaskSizes
   # has something to parse. The URL points nowhere reachable; HEAD will
   # fail and size stays 0, which is fine for this test.
   cat <<'EOF'
-[{"token":"firefox","url":"http://127.0.0.1:1/firefox.dmg"}]
+{"formulae":[],"casks":[{"token":"firefox","url":"http://127.0.0.1:1/firefox.dmg"}]}
 EOF
   exit 0
 fi
@@ -107,7 +107,7 @@ exit 0
 	var formulaInfo, caskInfo []string
 	for _, line := range strings.Split(strings.TrimSpace(string(logContent)), "\n") {
 		switch {
-		case strings.HasPrefix(line, "info --json --cask"):
+		case strings.HasPrefix(line, "info --json=v2 --cask"):
 			caskInfo = append(caskInfo, line)
 		case strings.HasPrefix(line, "info --json"):
 			formulaInfo = append(formulaInfo, line)
@@ -119,7 +119,7 @@ exit 0
 	assert.NotContains(t, formulaInfo[0], "firefox")
 
 	require.Len(t, caskInfo, 1, "cask size pre-fetch should be a single batch")
-	assert.Equal(t, "info --json --cask firefox", caskInfo[0])
+	assert.Equal(t, "info --json=v2 --cask firefox", caskInfo[0])
 }
 
 func TestInstallWithProgress_RetrySuccessTracksCanonicalNames(t *testing.T) {

--- a/internal/brew/install_progress_behavior_test.go
+++ b/internal/brew/install_progress_behavior_test.go
@@ -114,9 +114,14 @@ exit 0
 		}
 	}
 
-	require.Len(t, formulaInfo, 1, "formula alias resolution should be a single batch")
-	assert.Equal(t, "info --json postgresql kubectl", formulaInfo[0])
-	assert.NotContains(t, formulaInfo[0], "firefox")
+	// Two formula info calls are expected: one for alias resolution, one for
+	// size pre-fetch (FetchFormulaSizes). Both share the same arg shape —
+	// they're separate consumers of the same brew metadata.
+	require.Len(t, formulaInfo, 2, "expected one alias-resolution + one size pre-fetch call")
+	for _, line := range formulaInfo {
+		assert.Equal(t, "info --json postgresql kubectl", line)
+		assert.NotContains(t, line, "firefox", "formula info must never include cask names")
+	}
 
 	require.Len(t, caskInfo, 1, "cask size pre-fetch should be a single batch")
 	assert.Equal(t, "info --json=v2 --cask firefox", caskInfo[0])
@@ -192,6 +197,7 @@ exit 0
 
 	logContent, err := os.ReadFile(logPath)
 	require.NoError(t, err)
-	assert.Equal(t, 1, strings.Count(string(logContent), "info --json foo"))
+	// Two `info --json foo` calls: alias resolution + size pre-fetch.
+	assert.Equal(t, 2, strings.Count(string(logContent), "info --json foo"))
 	assert.Equal(t, 2, strings.Count(string(logContent), "install foo"))
 }

--- a/internal/brew/sizecheck.go
+++ b/internal/brew/sizecheck.go
@@ -10,13 +10,21 @@ import (
 	"github.com/openbootdotdev/openboot/internal/httputil"
 )
 
-// caskInfo is the subset of `brew info --json --cask` we care about.
+// caskInfo is the subset of `brew info --json=v2 --cask` we care about.
 type caskInfo struct {
 	Token string `json:"token"`
 	URL   string `json:"url"`
 }
 
-// FetchCaskSizes resolves each cask's download URL via `brew info --json
+// caskInfoEnvelope matches the v2 JSON schema: a top-level object with
+// "formulae" and "casks" arrays. (v1 returned a flat top-level array, but
+// brew rejects bare `--json` together with `--cask`, so we have to ask for
+// v2 explicitly — see https://docs.brew.sh/Manpage `brew info`.)
+type caskInfoEnvelope struct {
+	Casks []caskInfo `json:"casks"`
+}
+
+// FetchCaskSizes resolves each cask's download URL via `brew info --json=v2
 // --cask`, then issues HEAD requests in parallel to read Content-Length.
 // Returns a map[caskName]bytes; missing entries default to 0 (caller treats
 // as "size unknown — no live bytes display").
@@ -26,16 +34,17 @@ func FetchCaskSizes(ctx context.Context, casks []string) map[string]int64 {
 		return result
 	}
 
-	args := append([]string{"info", "--json", "--cask"}, casks...)
+	args := append([]string{"info", "--json=v2", "--cask"}, casks...)
 	output, err := currentRunner().Output(args...)
 	if err != nil {
 		return result
 	}
 
-	var entries []caskInfo
-	if err := json.Unmarshal(output, &entries); err != nil {
+	var env caskInfoEnvelope
+	if err := json.Unmarshal(output, &env); err != nil {
 		return result
 	}
+	entries := env.Casks
 
 	client := &http.Client{Timeout: 8 * time.Second}
 	var mu sync.Mutex

--- a/internal/brew/sizecheck.go
+++ b/internal/brew/sizecheck.go
@@ -78,3 +78,89 @@ func headContentLength(ctx context.Context, client *http.Client, url string) int
 	}
 	return resp.ContentLength
 }
+
+// ghcrAnonymousToken is the well-known token GHCR accepts for anonymous
+// public reads — base64 "A". brew uses the same token internally for bottle
+// HEAD/GET against ghcr.io.
+const ghcrAnonymousToken = "QQ=="
+
+// formulaInfo is the subset of `brew info --json <names>` we care about.
+// The v1 default schema returns a top-level array. Bottle URLs are nested
+// per-platform; we pick any one — sizes for the same formula are within
+// a few percent across platforms, accurate enough for bar progress.
+type formulaInfo struct {
+	Name   string `json:"name"`
+	Bottle struct {
+		Stable struct {
+			Files map[string]struct {
+				URL string `json:"url"`
+			} `json:"files"`
+		} `json:"stable"`
+	} `json:"bottle"`
+}
+
+// FetchFormulaSizes resolves each formula's bottle URL via `brew info --json`
+// and HEADs it (with the GHCR anonymous Bearer token) to read Content-Length.
+// Same fallback as FetchCaskSizes: missing entries default to 0.
+func FetchFormulaSizes(ctx context.Context, formulae []string) map[string]int64 {
+	result := make(map[string]int64, len(formulae))
+	if len(formulae) == 0 {
+		return result
+	}
+
+	args := append([]string{"info", "--json"}, formulae...)
+	output, err := currentRunner().Output(args...)
+	if err != nil {
+		return result
+	}
+
+	var entries []formulaInfo
+	if err := json.Unmarshal(output, &entries); err != nil {
+		return result
+	}
+
+	client := &http.Client{Timeout: 8 * time.Second}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, e := range entries {
+		url := pickBottleURL(e)
+		if url == "" {
+			result[e.Name] = 0
+			continue
+		}
+		wg.Add(1)
+		go func(name, url string) {
+			defer wg.Done()
+			size := headBottleContentLength(ctx, client, url)
+			mu.Lock()
+			result[name] = size
+			mu.Unlock()
+		}(e.Name, url)
+	}
+	wg.Wait()
+	return result
+}
+
+// pickBottleURL returns any bottle URL from the formula's stable files map.
+// Iteration order is unspecified but acceptable: bottles for the same formula
+// have near-identical sizes across platforms.
+func pickBottleURL(f formulaInfo) string {
+	for _, file := range f.Bottle.Stable.Files {
+		if file.URL != "" {
+			return file.URL
+		}
+	}
+	return ""
+}
+
+func headBottleContentLength(ctx context.Context, client *http.Client, url string) int64 {
+	resp, err := httputil.HeadWithBearer(ctx, client, url, ghcrAnonymousToken)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort body close
+	if resp.ContentLength < 0 {
+		return 0
+	}
+	return resp.ContentLength
+}

--- a/internal/brew/sizecheck_test.go
+++ b/internal/brew/sizecheck_test.go
@@ -49,3 +49,48 @@ func TestFetchCaskSizesSkipsHeadFailures(t *testing.T) {
 	// Failed HEAD leaves entry at 0 (caller treats as "unknown size").
 	assert.Equal(t, int64(0), sizes["broken"])
 }
+
+func TestFetchFormulaSizesReturnsBytesPerFormula(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// GHCR HEAD requires the anonymous Bearer token; refuse otherwise so
+		// the test pins both the URL plumbing and the auth header.
+		if r.Header.Get("Authorization") != "Bearer QQ==" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/jq.tar.gz":
+			w.Header().Set("Content-Length", "424157")
+		case "/ripgrep.tar.gz":
+			w.Header().Set("Content-Length", "2300000")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	withFakeBrew(t, func(args []string) ([]byte, error) {
+		// Formula info uses bare --json (v1, top-level array).
+		if len(args) >= 2 && args[0] == "info" && args[1] == "--json" {
+			return []byte(fmt.Sprintf(
+				`[{"name":"jq","bottle":{"stable":{"files":{"arm64_sequoia":{"url":"%s/jq.tar.gz"}}}}},`+
+					`{"name":"ripgrep","bottle":{"stable":{"files":{"arm64_sequoia":{"url":"%s/ripgrep.tar.gz"}}}}}]`,
+				srv.URL, srv.URL,
+			)), nil
+		}
+		return nil, fmt.Errorf("unexpected args: %v", args)
+	})
+
+	sizes := FetchFormulaSizes(context.Background(), []string{"jq", "ripgrep"})
+	assert.Equal(t, int64(424157), sizes["jq"])
+	assert.Equal(t, int64(2300000), sizes["ripgrep"])
+}
+
+func TestFetchFormulaSizesSkipsMissingBottle(t *testing.T) {
+	withFakeBrew(t, func(args []string) ([]byte, error) {
+		// No bottle.stable.files — formula has no bottle (e.g. head-only).
+		return []byte(`[{"name":"nobottle","bottle":{"stable":{"files":{}}}}]`), nil
+	})
+
+	sizes := FetchFormulaSizes(context.Background(), []string{"nobottle"})
+	assert.Equal(t, int64(0), sizes["nobottle"])
+}

--- a/internal/brew/sizecheck_test.go
+++ b/internal/brew/sizecheck_test.go
@@ -23,10 +23,12 @@ func TestFetchCaskSizesReturnsBytesPerCask(t *testing.T) {
 	defer srv.Close()
 
 	withFakeBrew(t, func(args []string) ([]byte, error) {
-		// Expect: brew info --json --cask docker rectangle
-		if len(args) >= 3 && args[0] == "info" && args[1] == "--json" && args[2] == "--cask" {
+		// Real brew rejects bare --json with --cask (it prints help text);
+		// the correct invocation is --json=v2 with a nested {"casks":[...]}
+		// envelope. Mirror that exactly here so tests reflect reality.
+		if len(args) >= 3 && args[0] == "info" && args[1] == "--json=v2" && args[2] == "--cask" {
 			return []byte(fmt.Sprintf(
-				`[{"token":"docker","url":"%s/docker.dmg"},{"token":"rectangle","url":"%s/rectangle.dmg"}]`,
+				`{"formulae":[],"casks":[{"token":"docker","url":"%s/docker.dmg"},{"token":"rectangle","url":"%s/rectangle.dmg"}]}`,
 				srv.URL, srv.URL,
 			)), nil
 		}
@@ -40,7 +42,7 @@ func TestFetchCaskSizesReturnsBytesPerCask(t *testing.T) {
 
 func TestFetchCaskSizesSkipsHeadFailures(t *testing.T) {
 	withFakeBrew(t, func(args []string) ([]byte, error) {
-		return []byte(`[{"token":"broken","url":"http://127.0.0.1:1/nope"}]`), nil
+		return []byte(`{"formulae":[],"casks":[{"token":"broken","url":"http://127.0.0.1:1/nope"}]}`), nil
 	})
 
 	sizes := FetchCaskSizes(context.Background(), []string{"broken"})

--- a/internal/httputil/head.go
+++ b/internal/httputil/head.go
@@ -15,3 +15,16 @@ func Head(ctx context.Context, client *http.Client, url string) (*http.Response,
 	}
 	return Do(client, req)
 }
+
+// HeadWithBearer is Head with an Authorization: Bearer <token> header. Used
+// for Homebrew bottle blobs hosted on ghcr.io, which return 401 to anonymous
+// HEAD requests but accept the well-known anonymous token "QQ==" (base64
+// "A") for public reads — the same trick brew uses internally.
+func HeadWithBearer(ctx context.Context, client *http.Client, url, token string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build HEAD request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return Do(client, req)
+}

--- a/internal/httputil/head_test.go
+++ b/internal/httputil/head_test.go
@@ -24,6 +24,21 @@ func TestHeadReturnsContentLength(t *testing.T) {
 	assert.Equal(t, int64(12345), resp.ContentLength)
 }
 
+func TestHeadWithBearerSendsAuthorization(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "HEAD", r.Method)
+		assert.Equal(t, "Bearer QQ==", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Length", "424157")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := HeadWithBearer(context.Background(), http.DefaultClient, srv.URL, "QQ==")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, int64(424157), resp.ContentLength)
+}
+
 func TestHeadFollowsRedirect(t *testing.T) {
 	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", "99")

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -66,12 +66,20 @@ type StickyProgress struct {
 	// switches to byte-based ETA when bytes are available.
 	phase Phase
 
-	// Cask-only: real-time download tracking.
+	// Cask-only: real-time download tracking for the current cask.
 	currentBytes int64
 	totalBytes   int64
 	speed        float64 // bytes/sec, EMA
 	lastBytes    int64
 	lastTime     time.Time
+
+	// Cask-only: aggregate byte progress across the whole cask phase, so the
+	// bar can be byte-proportional rather than count-proportional. The bar
+	// otherwise lies when casks vary by 10x in size (rectangle 4MB vs iina
+	// 104MB) — finishing the small ones first makes the count-based bar jump
+	// to "almost done" while most of the real work is still ahead.
+	phaseTotalBytes     int64
+	phaseCompletedBytes int64
 
 	// Scroll region rendering (nil when terminal doesn't support it).
 	region *ScrollRegion
@@ -213,10 +221,7 @@ func (sp *StickyProgress) formatLines() []string {
 		barWidth = defaultBarWidth
 	}
 
-	pct := float64(0)
-	if sp.total > 0 {
-		pct = float64(sp.completed) / float64(sp.total)
-	}
+	pct := sp.pctForBar()
 	filled := int(pct * float64(barWidth))
 	empty := barWidth - filled
 	bar := progressBarStyle.Render(strings.Repeat("█", filled)) +
@@ -263,7 +268,8 @@ func humanBytes(n int64) string {
 }
 
 // SetPhase switches between formula and cask data displays. Per-cask byte
-// state is cleared on each transition.
+// state is cleared on each transition; phase-wide byte aggregates are reset
+// too so a re-entry into the cask phase starts fresh.
 func (sp *StickyProgress) SetPhase(p Phase) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
@@ -271,6 +277,35 @@ func (sp *StickyProgress) SetPhase(p Phase) {
 	sp.currentBytes = 0
 	sp.totalBytes = 0
 	sp.speed = 0
+	sp.lastBytes = 0
+	sp.lastTime = time.Time{}
+	sp.phaseTotalBytes = 0
+	sp.phaseCompletedBytes = 0
+}
+
+// SetPhaseBytesTotal seeds the aggregate byte total for the current cask
+// phase. The bar uses this to render byte-proportional progress; without it
+// the bar falls back to count-proportional, which under-represents work
+// remaining when casks vary widely in size.
+func (sp *StickyProgress) SetPhaseBytesTotal(total int64) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.phaseTotalBytes = total
+}
+
+// AddCompletedCaskBytes accumulates the just-finished cask's known size into
+// the phase total. Pass 0 for casks whose size couldn't be pre-fetched —
+// they simply don't advance the bar.
+//
+// Per-cask state (currentBytes/totalBytes/lastBytes/lastTime) is cleared so
+// the next cask's tracker starts fresh and doesn't double-count. Speed is
+// kept across casks so the EMA carries the network estimate forward.
+func (sp *StickyProgress) AddCompletedCaskBytes(size int64) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.phaseCompletedBytes += size
+	sp.currentBytes = 0
+	sp.totalBytes = 0
 	sp.lastBytes = 0
 	sp.lastTime = time.Time{}
 }
@@ -283,6 +318,28 @@ func (sp *StickyProgress) SetCurrentBytes(current, total int64) {
 	defer sp.mu.Unlock()
 	sp.observeBytesAt(current, time.Now())
 	sp.totalBytes = total
+}
+
+// pctForBar returns the [0,1] progress fraction the bar should fill. For the
+// cask phase, when phase-byte data is available, it's byte-based across all
+// casks (so finishing a small cask doesn't jump the bar far). Otherwise it
+// falls back to count-based.
+func (sp *StickyProgress) pctForBar() float64 {
+	if sp.phase == PhaseCask && sp.phaseTotalBytes > 0 {
+		done := sp.phaseCompletedBytes + sp.currentBytes
+		pct := float64(done) / float64(sp.phaseTotalBytes)
+		if pct > 1 {
+			return 1
+		}
+		if pct < 0 {
+			return 0
+		}
+		return pct
+	}
+	if sp.total > 0 {
+		return float64(sp.completed) / float64(sp.total)
+	}
+	return 0
 }
 
 // observeBytesAt is the testable inner loop of SetCurrentBytes (lets tests

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -73,13 +73,13 @@ type StickyProgress struct {
 	lastBytes    int64
 	lastTime     time.Time
 
-	// Cask-only: aggregate byte progress across the whole cask phase, so the
-	// bar can be byte-proportional rather than count-proportional. The bar
-	// otherwise lies when casks vary by 10x in size (rectangle 4MB vs iina
-	// 104MB) — finishing the small ones first makes the count-based bar jump
-	// to "almost done" while most of the real work is still ahead.
-	phaseTotalBytes     int64
-	phaseCompletedBytes int64
+	// Aggregate byte progress across the WHOLE install (formula + cask), so
+	// the bar is byte-proportional rather than count-proportional. The bar
+	// otherwise lies when packages vary by 10x in size — finishing several
+	// small formulae makes a count-based bar jump well past where the real
+	// work is (most of which is in the few large casks).
+	installTotalBytes     int64
+	installCompletedBytes int64
 
 	// Scroll region rendering (nil when terminal doesn't support it).
 	region *ScrollRegion
@@ -267,9 +267,10 @@ func humanBytes(n int64) string {
 	}
 }
 
-// SetPhase switches between formula and cask data displays. Per-cask byte
-// state is cleared on each transition; phase-wide byte aggregates are reset
-// too so a re-entry into the cask phase starts fresh.
+// SetPhase switches between formula and cask data displays. Affects only
+// what the head shows (formula = count only, cask = bytes/speed/ETA); the
+// bar uses install-wide byte progress and is unaffected. Per-package byte
+// state is cleared as a hygiene measure for the new phase.
 func (sp *StickyProgress) SetPhase(p Phase) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
@@ -279,31 +280,29 @@ func (sp *StickyProgress) SetPhase(p Phase) {
 	sp.speed = 0
 	sp.lastBytes = 0
 	sp.lastTime = time.Time{}
-	sp.phaseTotalBytes = 0
-	sp.phaseCompletedBytes = 0
 }
 
-// SetPhaseBytesTotal seeds the aggregate byte total for the current cask
-// phase. The bar uses this to render byte-proportional progress; without it
-// the bar falls back to count-proportional, which under-represents work
-// remaining when casks vary widely in size.
-func (sp *StickyProgress) SetPhaseBytesTotal(total int64) {
+// SetTotalBytes seeds the aggregate byte total for the whole install
+// (formula + cask combined). The bar uses this to render byte-proportional
+// progress; without it the bar falls back to count-proportional.
+func (sp *StickyProgress) SetTotalBytes(total int64) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
-	sp.phaseTotalBytes = total
+	sp.installTotalBytes = total
 }
 
-// AddCompletedCaskBytes accumulates the just-finished cask's known size into
-// the phase total. Pass 0 for casks whose size couldn't be pre-fetched —
-// they simply don't advance the bar.
+// AddCompletedBytes accumulates the just-finished package's known size into
+// the install total. Pass 0 for packages whose size couldn't be pre-fetched
+// — they simply don't advance the bar.
 //
-// Per-cask state (currentBytes/totalBytes/lastBytes/lastTime) is cleared so
-// the next cask's tracker starts fresh and doesn't double-count. Speed is
-// kept across casks so the EMA carries the network estimate forward.
-func (sp *StickyProgress) AddCompletedCaskBytes(size int64) {
+// Per-package state (currentBytes/totalBytes/lastBytes/lastTime) is cleared
+// so the next package's tracker starts fresh and doesn't double-count.
+// Speed is kept across packages so the EMA carries the network estimate
+// forward.
+func (sp *StickyProgress) AddCompletedBytes(size int64) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
-	sp.phaseCompletedBytes += size
+	sp.installCompletedBytes += size
 	sp.currentBytes = 0
 	sp.totalBytes = 0
 	sp.lastBytes = 0
@@ -320,14 +319,15 @@ func (sp *StickyProgress) SetCurrentBytes(current, total int64) {
 	sp.totalBytes = total
 }
 
-// pctForBar returns the [0,1] progress fraction the bar should fill. For the
-// cask phase, when phase-byte data is available, it's byte-based across all
-// casks (so finishing a small cask doesn't jump the bar far). Otherwise it
-// falls back to count-based.
+// pctForBar returns the [0,1] progress fraction the bar should fill. The
+// bar is byte-based across the WHOLE install (formula + cask) when total
+// bytes are known, so it advances continuously through both phases instead
+// of using two separate algorithms with a jump in between. Falls back to
+// count-based if no byte data is available at all.
 func (sp *StickyProgress) pctForBar() float64 {
-	if sp.phase == PhaseCask && sp.phaseTotalBytes > 0 {
-		done := sp.phaseCompletedBytes + sp.currentBytes
-		pct := float64(done) / float64(sp.phaseTotalBytes)
+	if sp.installTotalBytes > 0 {
+		done := sp.installCompletedBytes + sp.currentBytes
+		pct := float64(done) / float64(sp.installTotalBytes)
 		if pct > 1 {
 			return 1
 		}

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -146,7 +146,7 @@ func (sp *StickyProgress) Start() {
 
 func (sp *StickyProgress) render() {
 	if sp.region != nil {
-		sp.region.DrawTop(sp.formatLines())
+		sp.region.DrawBottom(sp.formatLines())
 		return
 	}
 	sp.renderInline()
@@ -183,8 +183,10 @@ func (sp *StickyProgress) renderInline() {
 		currentPkgStyle.Render(pkgDisplay))
 }
 
-// formatLines returns the two strings to render in the scroll region:
-// row 1 = data + bar, row 2 = divider line.
+// formatLines returns the two strings to render in the bottom-reserved
+// scroll region. Order matches top-to-bottom layout: the divider sits above
+// the data row so it visually separates the scrolling output from the
+// status line at the very last terminal row.
 func (sp *StickyProgress) formatLines() []string {
 	var head string
 	switch sp.phase {
@@ -220,9 +222,9 @@ func (sp *StickyProgress) formatLines() []string {
 	bar := progressBarStyle.Render(strings.Repeat("█", filled)) +
 		progressBgStyle.Render(strings.Repeat("░", empty))
 
-	line1 := fmt.Sprintf("%s %s %3d%%", head, bar, int(pct*100))
-	line2 := strings.Repeat("─", cols)
-	return []string{line1, line2}
+	divider := strings.Repeat("─", cols)
+	status := fmt.Sprintf("%s %s %3d%%", head, bar, int(pct*100))
+	return []string{divider, status}
 }
 
 func (sp *StickyProgress) formatFormulaHead() string {

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -143,81 +143,76 @@ func TestStickyProgressSetCurrentDoesNotPanic(t *testing.T) {
 
 func TestStickyProgressSetPhase(t *testing.T) {
 	sp := NewStickyProgress(10)
-	// Seed some byte state from a "previous" cask.
+	// Seed some byte state from a "previous" package and install-wide totals.
 	sp.currentBytes = 999
 	sp.totalBytes = 9999
 	sp.speed = 1234
 	sp.lastBytes = 999
 	sp.lastTime = time.Unix(42, 0)
-	sp.phaseTotalBytes = 5_000_000
-	sp.phaseCompletedBytes = 2_000_000
+	sp.installTotalBytes = 5_000_000
+	sp.installCompletedBytes = 2_000_000
 
 	sp.SetPhase(PhaseCask)
 	assert.Equal(t, PhaseCask, sp.phase)
 
-	// SetPhase must reset all per-cask byte state so the next cask
-	// starts clean (no stale bytes bleeding into the bar). Phase-wide
-	// aggregates reset too — re-entering the cask phase starts fresh.
+	// SetPhase clears per-package byte state for a clean start.
 	assert.EqualValues(t, 0, sp.currentBytes)
 	assert.EqualValues(t, 0, sp.totalBytes)
 	assert.InDelta(t, 0, sp.speed, 0.01)
 	assert.EqualValues(t, 0, sp.lastBytes)
 	assert.True(t, sp.lastTime.IsZero())
-	assert.EqualValues(t, 0, sp.phaseTotalBytes)
-	assert.EqualValues(t, 0, sp.phaseCompletedBytes)
+	// Install-wide aggregates are NOT touched — they span both phases.
+	assert.EqualValues(t, 5_000_000, sp.installTotalBytes)
+	assert.EqualValues(t, 2_000_000, sp.installCompletedBytes)
 }
 
-func TestStickyProgressPctForBarByteBased(t *testing.T) {
-	sp := NewStickyProgress(3)
-	sp.SetPhase(PhaseCask)
-	sp.SetPhaseBytesTotal(100_000_000) // 100 MB across the cask phase
+func TestStickyProgressPctForBarByteBasedAcrossPhases(t *testing.T) {
+	sp := NewStickyProgress(5)
+	// Total install: 5 formulae + 2 casks = some bytes mix.
+	sp.SetTotalBytes(100_000_000) // 100 MB across the whole install
 
-	// Nothing started yet → 0%.
+	// Nothing started → 0%.
 	assert.InDelta(t, 0, sp.pctForBar(), 0.001)
 
-	// Mid-download of first cask: 30M of 100M.
-	sp.SetCurrentBytes(30_000_000, 100_000_000)
-	assert.InDelta(t, 0.3, sp.pctForBar(), 0.001)
+	// Formula phase: each formula complete adds its size lump-sum (no tracker).
+	sp.SetPhase(PhaseFormula)
+	sp.AddCompletedBytes(5_000_000) // first formula done: 5MB
+	assert.InDelta(t, 0.05, sp.pctForBar(), 0.001)
 
-	// First cask done — 40M cask actually, advance the aggregate.
-	sp.AddCompletedCaskBytes(40_000_000)
-	assert.InDelta(t, 0.4, sp.pctForBar(), 0.001)
+	sp.AddCompletedBytes(3_000_000) // second formula done: 3MB. Total 8MB.
+	assert.InDelta(t, 0.08, sp.pctForBar(), 0.001)
 
-	// Second cask mid-download: 30M of 60M, on top of the 40M already done.
+	// Cask phase. Mid-download of first cask: 30M of 60M.
+	sp.SetPhase(PhaseCask)
 	sp.SetCurrentBytes(30_000_000, 60_000_000)
-	// (40 + 30) / 100 = 0.7
-	assert.InDelta(t, 0.7, sp.pctForBar(), 0.001)
+	// 8M done + 30M in flight = 38M / 100M = 0.38.
+	assert.InDelta(t, 0.38, sp.pctForBar(), 0.001)
+
+	// First cask done (60MB).
+	sp.AddCompletedBytes(60_000_000)
+	// 8 + 60 = 68 / 100 = 0.68. currentBytes was cleared.
+	assert.InDelta(t, 0.68, sp.pctForBar(), 0.001)
 }
 
 func TestStickyProgressPctForBarFallsBackToCount(t *testing.T) {
 	sp := NewStickyProgress(4)
-	sp.SetPhase(PhaseCask)
-	// phaseTotalBytes left at 0 (e.g. all HEAD pre-fetches failed) → count-based.
+	// installTotalBytes left at 0 (e.g. all HEAD pre-fetches failed) → count-based.
 	sp.completed = 2
 	assert.InDelta(t, 0.5, sp.pctForBar(), 0.001)
 }
 
-func TestStickyProgressPctForBarFormulaPhaseUsesCount(t *testing.T) {
-	sp := NewStickyProgress(10)
-	// PhaseFormula is the default. Byte aggregates should be ignored even if set.
-	sp.phaseTotalBytes = 999_999_999
-	sp.phaseCompletedBytes = 500_000_000
-	sp.completed = 3
-	assert.InDelta(t, 0.3, sp.pctForBar(), 0.001)
-}
-
-func TestStickyProgressAddCompletedCaskBytesResetsCurrent(t *testing.T) {
+func TestStickyProgressAddCompletedBytesResetsCurrent(t *testing.T) {
 	sp := NewStickyProgress(3)
+	sp.SetTotalBytes(100_000_000)
 	sp.SetPhase(PhaseCask)
-	sp.SetPhaseBytesTotal(100_000_000)
 	sp.SetCurrentBytes(40_000_000, 40_000_000)
 	sp.speed = 5_000_000 // pretend EMA is established
 
-	sp.AddCompletedCaskBytes(40_000_000)
+	sp.AddCompletedBytes(40_000_000)
 
-	// Per-cask state cleared, but speed kept (it's a network-level estimate
-	// that should carry across casks).
-	assert.EqualValues(t, 40_000_000, sp.phaseCompletedBytes)
+	// Per-package state cleared, but speed kept (it's a network-level estimate
+	// that should carry across packages).
+	assert.EqualValues(t, 40_000_000, sp.installCompletedBytes)
 	assert.EqualValues(t, 0, sp.currentBytes)
 	assert.EqualValues(t, 0, sp.totalBytes)
 	assert.EqualValues(t, 0, sp.lastBytes)

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -149,17 +149,80 @@ func TestStickyProgressSetPhase(t *testing.T) {
 	sp.speed = 1234
 	sp.lastBytes = 999
 	sp.lastTime = time.Unix(42, 0)
+	sp.phaseTotalBytes = 5_000_000
+	sp.phaseCompletedBytes = 2_000_000
 
 	sp.SetPhase(PhaseCask)
 	assert.Equal(t, PhaseCask, sp.phase)
 
 	// SetPhase must reset all per-cask byte state so the next cask
-	// starts clean (no stale bytes bleeding into the bar).
+	// starts clean (no stale bytes bleeding into the bar). Phase-wide
+	// aggregates reset too — re-entering the cask phase starts fresh.
 	assert.EqualValues(t, 0, sp.currentBytes)
 	assert.EqualValues(t, 0, sp.totalBytes)
 	assert.InDelta(t, 0, sp.speed, 0.01)
 	assert.EqualValues(t, 0, sp.lastBytes)
 	assert.True(t, sp.lastTime.IsZero())
+	assert.EqualValues(t, 0, sp.phaseTotalBytes)
+	assert.EqualValues(t, 0, sp.phaseCompletedBytes)
+}
+
+func TestStickyProgressPctForBarByteBased(t *testing.T) {
+	sp := NewStickyProgress(3)
+	sp.SetPhase(PhaseCask)
+	sp.SetPhaseBytesTotal(100_000_000) // 100 MB across the cask phase
+
+	// Nothing started yet → 0%.
+	assert.InDelta(t, 0, sp.pctForBar(), 0.001)
+
+	// Mid-download of first cask: 30M of 100M.
+	sp.SetCurrentBytes(30_000_000, 100_000_000)
+	assert.InDelta(t, 0.3, sp.pctForBar(), 0.001)
+
+	// First cask done — 40M cask actually, advance the aggregate.
+	sp.AddCompletedCaskBytes(40_000_000)
+	assert.InDelta(t, 0.4, sp.pctForBar(), 0.001)
+
+	// Second cask mid-download: 30M of 60M, on top of the 40M already done.
+	sp.SetCurrentBytes(30_000_000, 60_000_000)
+	// (40 + 30) / 100 = 0.7
+	assert.InDelta(t, 0.7, sp.pctForBar(), 0.001)
+}
+
+func TestStickyProgressPctForBarFallsBackToCount(t *testing.T) {
+	sp := NewStickyProgress(4)
+	sp.SetPhase(PhaseCask)
+	// phaseTotalBytes left at 0 (e.g. all HEAD pre-fetches failed) → count-based.
+	sp.completed = 2
+	assert.InDelta(t, 0.5, sp.pctForBar(), 0.001)
+}
+
+func TestStickyProgressPctForBarFormulaPhaseUsesCount(t *testing.T) {
+	sp := NewStickyProgress(10)
+	// PhaseFormula is the default. Byte aggregates should be ignored even if set.
+	sp.phaseTotalBytes = 999_999_999
+	sp.phaseCompletedBytes = 500_000_000
+	sp.completed = 3
+	assert.InDelta(t, 0.3, sp.pctForBar(), 0.001)
+}
+
+func TestStickyProgressAddCompletedCaskBytesResetsCurrent(t *testing.T) {
+	sp := NewStickyProgress(3)
+	sp.SetPhase(PhaseCask)
+	sp.SetPhaseBytesTotal(100_000_000)
+	sp.SetCurrentBytes(40_000_000, 40_000_000)
+	sp.speed = 5_000_000 // pretend EMA is established
+
+	sp.AddCompletedCaskBytes(40_000_000)
+
+	// Per-cask state cleared, but speed kept (it's a network-level estimate
+	// that should carry across casks).
+	assert.EqualValues(t, 40_000_000, sp.phaseCompletedBytes)
+	assert.EqualValues(t, 0, sp.currentBytes)
+	assert.EqualValues(t, 0, sp.totalBytes)
+	assert.EqualValues(t, 0, sp.lastBytes)
+	assert.True(t, sp.lastTime.IsZero())
+	assert.InDelta(t, 5_000_000, sp.speed, 0.01)
 }
 
 func TestStickyProgressSetCurrentBytes(t *testing.T) {

--- a/internal/ui/scrollregion.go
+++ b/internal/ui/scrollregion.go
@@ -13,10 +13,15 @@ import (
 // non-region path.
 const minRowsForRegion = 6
 
-// ScrollRegion owns the ANSI plumbing for reserving the top N rows as a
-// "frozen" region while output below scrolls. Use IsScrollRegionSupported to
-// check before enabling; on unsupported terminals, callers should render
+// ScrollRegion owns the ANSI plumbing for reserving the bottom N rows as a
+// "frozen" status area while output above scrolls. Use IsScrollRegionSupported
+// to check before enabling; on unsupported terminals, callers should render
 // inline instead.
+//
+// We chose the bottom over the top because a top-reserved region puts the
+// progress bar at the very top of the terminal viewport — far from where the
+// user actually typed the command. The bottom mirrors how tmux/screen status
+// bars sit and stays closer to the user's eye-line for a one-shot CLI run.
 type ScrollRegion struct {
 	w        io.Writer
 	rows     int
@@ -26,7 +31,7 @@ type ScrollRegion struct {
 }
 
 // NewScrollRegion constructs a scroll region for stdout with the given number
-// of reserved top rows. Caller must invoke Start before drawing and Stop on
+// of reserved bottom rows. Caller must invoke Start before drawing and Stop on
 // teardown (defer / signal handler).
 func NewScrollRegion(reserved int) *ScrollRegion {
 	w, h := terminalSize()
@@ -53,10 +58,11 @@ func (r *ScrollRegion) Stop() {
 	r.active = false
 }
 
-// DrawTop writes lines to the reserved region without disturbing the cursor
-// in the scrolling area. len(lines) must be <= reserved.
-func (r *ScrollRegion) DrawTop(lines []string) {
-	r.drawTop(lines)
+// DrawBottom writes lines to the reserved region without disturbing the cursor
+// in the scrolling area. lines[0] goes to the topmost reserved row, lines[N-1]
+// to the bottommost. len(lines) must be <= reserved.
+func (r *ScrollRegion) DrawBottom(lines []string) {
+	r.drawBottom(lines)
 }
 
 // Cols returns the current terminal width.
@@ -70,28 +76,39 @@ func (r *ScrollRegion) write(format string, args ...interface{}) {
 }
 
 func (r *ScrollRegion) reserve() {
-	// Hide cursor, set scroll region from row (reserved+1) to last row,
-	// then move cursor into the scroll region.
+	// Hide cursor, set scroll region from row 1 to (rows-reserved), then
+	// move the cursor to the last row of the scrollable area so new output
+	// prints just above the reserved bottom rows.
 	r.write("\x1b[?25l")
-	r.write("\x1b[%d;%dr", r.reserved+1, r.rows)
-	r.write("\x1b[%d;1H", r.reserved+1)
+	r.write("\x1b[1;%dr", r.rows-r.reserved)
+	r.write("\x1b[%d;1H", r.rows-r.reserved)
 }
 
 func (r *ScrollRegion) reset() {
-	// Reset scroll region, show cursor, move cursor to the bottom row.
+	// Clear the reserved rows before releasing the region so the bar
+	// doesn't leave residue at the bottom of the scrollback. Save/restore
+	// keeps the cursor at whatever position the scrolling content left it,
+	// so subsequent prompts append naturally.
+	r.write("\x1b7")
+	for i := 0; i < r.reserved; i++ {
+		row := r.rows - r.reserved + 1 + i
+		r.write("\x1b[%d;1H\x1b[2K", row)
+	}
+	r.write("\x1b8")
 	r.write("\x1b[r")
 	r.write("\x1b[?25h")
-	r.write("\x1b[%d;1H", r.rows)
 }
 
-func (r *ScrollRegion) drawTop(lines []string) {
+func (r *ScrollRegion) drawBottom(lines []string) {
 	if len(lines) > r.reserved {
 		panic(fmt.Sprintf("scrollregion: %d lines exceed reserved %d", len(lines), r.reserved))
 	}
-	// DEC save cursor, draw each reserved row from top, restore.
+	// DEC save cursor (caller's position in the scrolling area), draw each
+	// reserved row from the top of the reserved band downward, then restore.
 	r.write("\x1b7")
 	for i, line := range lines {
-		r.write("\x1b[%d;1H\x1b[2K%s", i+1, line)
+		row := r.rows - r.reserved + 1 + i
+		r.write("\x1b[%d;1H\x1b[2K%s", row, line)
 	}
 	r.write("\x1b8")
 }

--- a/internal/ui/scrollregion_test.go
+++ b/internal/ui/scrollregion_test.go
@@ -40,40 +40,51 @@ func TestScrollRegionReserveEmitsSequence(t *testing.T) {
 	var buf bytes.Buffer
 	r := &ScrollRegion{w: &buf, rows: 24, cols: 80, reserved: 2}
 	r.reserve()
-	// Expected: hide cursor, set scroll region rows 3..24, move cursor into region.
-	assert.Contains(t, buf.String(), "\x1b[?25l")
-	assert.Contains(t, buf.String(), "\x1b[3;24r")
-	assert.Contains(t, buf.String(), "\x1b[3;1H")
+	out := buf.String()
+	// Expected: hide cursor, set scroll region rows 1..(24-2)=22, move cursor
+	// to the last row of the scrollable area (row 22).
+	assert.Contains(t, out, "\x1b[?25l")
+	assert.Contains(t, out, "\x1b[1;22r")
+	assert.Contains(t, out, "\x1b[22;1H")
 }
 
-func TestScrollRegionResetEmitsSequence(t *testing.T) {
+func TestScrollRegionResetClearsReservedRowsAndReleasesRegion(t *testing.T) {
 	var buf bytes.Buffer
 	r := &ScrollRegion{w: &buf, rows: 24, cols: 80, reserved: 2}
 	r.reset()
-	// Expected: reset scroll region, show cursor, move cursor to bottom.
-	assert.Contains(t, buf.String(), "\x1b[r")
-	assert.Contains(t, buf.String(), "\x1b[?25h")
-	assert.Contains(t, buf.String(), "\x1b[24;1H")
+	out := buf.String()
+	// Reset must:
+	//  1. clear each reserved row (rows 23 and 24 with EL2 = \x1b[2K)
+	//  2. release the scroll region (\x1b[r)
+	//  3. show the cursor (\x1b[?25h)
+	//  4. preserve the caller's cursor position via DEC save/restore
+	assert.Contains(t, out, "\x1b7")
+	assert.Contains(t, out, "\x1b[23;1H\x1b[2K")
+	assert.Contains(t, out, "\x1b[24;1H\x1b[2K")
+	assert.Contains(t, out, "\x1b8")
+	assert.Contains(t, out, "\x1b[r")
+	assert.Contains(t, out, "\x1b[?25h")
 }
 
-func TestScrollRegionDrawTopUsesSaveRestoreCursor(t *testing.T) {
+func TestScrollRegionDrawBottomUsesSaveRestoreCursor(t *testing.T) {
 	var buf bytes.Buffer
 	r := &ScrollRegion{w: &buf, rows: 24, cols: 80, reserved: 2}
-	r.drawTop([]string{"line one", "line two"})
+	r.drawBottom([]string{"line one", "line two"})
 	out := buf.String()
 	// DEC save (\x1b7) before, DEC restore (\x1b8) after.
+	// With rows=24, reserved=2: lines write to rows 23 and 24.
 	assert.Contains(t, out, "\x1b7")
 	assert.Contains(t, out, "\x1b8")
-	assert.Contains(t, out, "\x1b[1;1H")
-	assert.Contains(t, out, "\x1b[2;1H")
+	assert.Contains(t, out, "\x1b[23;1H")
+	assert.Contains(t, out, "\x1b[24;1H")
 	assert.Contains(t, out, "line one")
 	assert.Contains(t, out, "line two")
 }
 
-func TestScrollRegionDrawTopTooManyLinesPanics(t *testing.T) {
+func TestScrollRegionDrawBottomTooManyLinesPanics(t *testing.T) {
 	var buf bytes.Buffer
 	r := &ScrollRegion{w: &buf, rows: 24, cols: 80, reserved: 2}
 	assert.Panics(t, func() {
-		r.drawTop([]string{"a", "b", "c"}) // reserved=2, given 3
+		r.drawBottom([]string{"a", "b", "c"}) // reserved=2, given 3
 	})
 }


### PR DESCRIPTION
## Summary

Follow-up to #76 fixing three real problems caught during manual smoke testing:

1. **Scroll region was anchored to the top of the viewport, far from where the user typed the command.** Mirrored tmux's bottom status bar: reserve the LAST two rows so the bar appears near the user's eye-line. `reset()` now also clears the reserved rows so the bar doesn't leave residue in the scrollback.

2. **Cask bytes/speed/ETA never updated — stuck on `—` for every cask.** `brew info --json --cask <name>` prints help text (exit 0) instead of JSON; the correct invocation is `--json=v2`. The fake brew runner in tests matched our buggy expectation instead of brew's actual CLI grammar, hiding the bug. Switched to `--json=v2` and updated both fakes to mirror reality.

3. **Bar was count-based.** For a mix of small formulae (5MB) + large casks (104MB), the bar would jump to "50% done" after the small ones finished while most real work remained. Replaced with byte-based progress across the WHOLE install (formula + cask, single continuous bar). Formula bottle sizes are HEAD'd via GHCR's anonymous Bearer token (`QQ==`, the same trick brew uses internally) — a new `httputil.HeadWithBearer` keeps HTTP construction inside `internal/httputil/` per archtest.

Plus one small polish: at each cask entry, seed `totalBytes` from the known size so the head shows `0B/<size>` immediately instead of `—` for the ~500ms before the cache tracker's first poll.

## Test plan

- [x] L1 (`make test-unit`) green across all packages
- [x] `-race` clean on `internal/brew` and `internal/ui`
- [x] Archtest baselines updated (line shift in `brew_install.go` after the new sizes pre-fetch block)
- [x] New tests: `HeadWithBearer` sends the Authorization header; `FetchFormulaSizes` happy + missing-bottle paths; `pctForBar` byte-based across phases + count-based fallback + Phase reset semantics
- [x] **Manual smoke in real Ghostty** (this time actually done): installed 5 formulae + 5 casks of varying size (jq/ripgrep/fzf/bat/tree + rectangle/stats/alt-tab/keka/iina). Verified:
  - Bar sits at the bottom of the terminal, not the top
  - `[7/10] alt-tab` ≈ 10% (formulae + 2 small casks ≈ 21MB of 174MB)
  - `[8/10] keka 35M/35M` ≈ 38% (3 casks + formulae done, keka downloaded)
  - Math checks out, continuous progression with no phase jump
  - Scroll region releases cleanly, prompt returns normal

## Process note

Both problem 1 (scroll region placement) and problem 2 (`--json` flag) slipped through #76's review because **the test fakes documented our buggy expectations instead of brew's reality**. The fakes only checked `args[1] == "--json"` — they didn't validate brew would accept that combination. Real brew rejects it. Lesson logged for future PRs that touch brew CLI grammar: at least one integration test must fork real `brew` (or the contract test suite must cover the call shape).