### PR TITLE
feat(release): auto-generate release notes from Conventional Commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
 
       - name: Write release notes
         run: |
+          # Static template — installation + binaries.
           cat > release_notes.md << 'EOF'
           ## Installation
 
@@ -195,6 +196,35 @@ jobs:
           | macOS | Intel | `openboot-darwin-amd64` |
           EOF
           sed -i 's/^          //' release_notes.md
+
+          # Auto-generated changelog from Conventional Commits since the
+          # previous tag, grouped by type. Non-conventional commits are
+          # intentionally dropped — they should be rare (CLAUDE.md enforces
+          # the convention) and silence is better than a misleading row.
+          # Skipped entirely on the first release (no prior tag).
+          VERSION="${{ needs.detect-release-type.outputs.version }}"
+          PREV_TAG=$(git describe --tags --abbrev=0 "${VERSION}^" 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            {
+              echo ""
+              echo "## What's Changed"
+              echo ""
+              for entry in "feat:Features" "fix:Bug Fixes" "perf:Performance" "refactor:Refactors" "docs:Docs" "test:Tests" "chore:Chores" "ci:CI"; do
+                prefix="${entry%%:*}"
+                heading="${entry#*:}"
+                lines=$(git log --pretty='format:- %s' "${PREV_TAG}..${VERSION}" | grep -E "^- ${prefix}(\(|:)" || true)
+                if [ -n "$lines" ]; then
+                  echo "### ${heading}"
+                  echo ""
+                  printf '%s\n' "$lines"
+                  echo ""
+                fi
+              done
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${VERSION}"
+            } >> release_notes.md
+          fi
+          echo "----- generated release_notes.md -----"
+          cat release_notes.md
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -52,6 +52,7 @@ Three regulation categories:
 | Behav. | L5 destructive (real installs) | release tags, manual dispatch | `make test-destructive` |
 | Behav. | curl\|bash smoke (install.sh + mock server) | every PR | `.github/workflows/test.yml` `curl-bash-smoke` job |
 | Behav. | Auto-release sensor — tag + dispatch `release.yml` when unreleased commits trip a threshold (`>=5 feat/fix`, `>=7 days + new`, or any `fix:` for patch fast lane) | push to `main` | `.github/workflows/auto-release.yml` |
+| Behav. | Release notes — Conventional Commits since previous tag, grouped by type (Features / Bug Fixes / etc) + Full Changelog link, appended to the install-instructions template | tag push or `workflow_dispatch` | `.github/workflows/release.yml` (`Write release notes` step) |
 | Behav. | Old-CLI compat (previous release × current mock server) | every PR | `.github/workflows/test.yml` `cli-compat` job |
 | Feedfwd. | Agent conventions | every AI turn | `CLAUDE.md`, `AGENTS.md` |
 | Feedfwd. | Skills | model-loaded | `.claude/skills/*` |


### PR DESCRIPTION
## Summary

The release body was a static "Installation + Binaries" template — every release looked identical with **zero mention of what changed**. v0.58.0 is the latest example: bundled both #76 (the new progress bar) and #77 (the fixes), but the GitHub release page tells the user nothing about either.

Append a "What's Changed" section generated from `git log <prev-tag>..<version>`, grouped by Conventional Commit type (Features / Bug Fixes / Performance / Refactors / Docs / Tests / Chores / CI), with a Full Changelog compare link.

Validated locally against `v0.57.0..v0.58.0`:

```
## What's Changed

### Features
- feat(install): real-time progress bar for cask downloads via scroll region (#76)

### Bug Fixes
- fix(install): bottom-anchored progress bar + real byte tracking (#77)

**Full Changelog**: https://github.com/openbootdotdev/openboot/compare/v0.57.0...v0.58.0
```

## Harness rationale

Per `docs/HARNESS.md`, repeated friction becomes a control. "Release notes are blank" was previously the kind of thing that gets noticed AFTER each release. Encoding it as a workflow step means the next release (and every release after) writes them automatically — no manual step to forget. Added a row to the controls table so the next agent that goes looking for "where is this generated" finds it directly.

## What this does NOT do

- Doesn't backfill v0.58.0's notes — that's a one-shot `gh release edit` after merge
- Doesn't change `auto-release.yml` — release dispatch logic untouched
- Doesn't add a tool dependency — pure bash + git, runs on the existing release runner

## Test plan

- [x] Smoke-tested the generator shell logic locally against `v0.57.0..v0.58.0`, output matches the expected grouping
- [x] Conventional commit prefix regex tolerates both `feat:` and `feat(scope):` forms
- [x] First-release edge case handled (`git describe --tags --abbrev=0 ^` returns empty → skip the "What's Changed" section entirely)
- [ ] Next real release that fires `release.yml` will validate end-to-end (workflow_dispatch can also be used to re-run for v0.58.0 once this lands)