### PR TITLE
docs(install): clarify --silent help text and field comment

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -63,7 +63,7 @@ func init() {
 	installCmd.Flags().StringVarP(&installCfg.Preset, "preset", "p", "", "use a preset: minimal, developer, full")
 	installCmd.Flags().StringVarP(&installCfg.User, "user", "u", "", "install from an alias or openboot.dev/username/slug config")
 	installCmd.Flags().String("from", "", "install from a local config or snapshot JSON file")
-	installCmd.Flags().BoolVarP(&installCfg.Silent, "silent", "s", false, "non-interactive mode (for CI/CD)")
+	installCmd.Flags().BoolVarP(&installCfg.Silent, "silent", "s", false, "non-interactive mode (no TTY prompts; for scripts and e2e)")
 	installCmd.Flags().BoolVar(&installCfg.DryRun, "dry-run", false, "preview changes without installing")
 	installCmd.Flags().BoolVar(&installCfg.PackagesOnly, "packages-only", false, "install packages only, skip system config")
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -15,7 +15,7 @@ type Config struct {
 	Preset           string // -p / OPENBOOT_PRESET
 	User             string // -u / OPENBOOT_USER
 	DryRun           bool   // --dry-run
-	Silent           bool   // -s / CI mode
+	Silent           bool   // -s / non-interactive: no TTY prompts (scripts, e2e)
 	PackagesOnly     bool   // --packages-only
 	Update           bool   // --update
 	Shell            string // --shell (install|skip)


### PR DESCRIPTION
## Summary

- Flag help said "non-interactive mode (for CI/CD)", but the only actual callers of `--silent` are `test/e2e/*` (Tart VM, no PTY) and `scripts/install.sh`'s curl|bash example. Real CI (GitHub Actions) never runs `openboot install`.
- Updates `internal/cli/install.go` help text + matching `Silent` field comment in `internal/config/types.go` to describe what the mode actually does.
- Flag name (`--silent`) is unchanged — renaming would be breaking for users' scripts / dotfiles / MDM payloads.

## Test plan

- [x] `go vet ./internal/cli/... ./internal/config/...` clean
- [x] L1 (pre-push hook) green
- [ ] CI green