### PR TITLE
chore(ci): disable Codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,4 @@ coverage:
         threshold: 50%
         informational: true
 
-comment:
-  layout: "reach,diff,flags,tree"
-  behavior: default
-  require_changes: false
+comment: false


### PR DESCRIPTION
## Summary

- Replaces the verbose `comment` block in `codecov.yml` with `comment: false`
- Coverage reports continue via email; PR comment noise is eliminated

## Test plan

- [ ] Merge and open a subsequent PR — no Codecov bot comment should appear