### PR TITLE
ci: add L4 vm-e2e as gate in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,44 @@ jobs:
       - name: Unit tests
         run: make test-unit
 
+  l4-group-a:
+    needs: gate-tests
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build binary
+        run: make build
+      - name: Run group-a tests
+        run: |
+          go test -v -timeout 55m -tags="e2e,vm" \
+            -run 'TestVM_Journey_FirstTimeUser|TestVM_Journey_DryRunIsCompletelySafe|TestVM_Interactive_InstallScript' \
+            ./test/e2e/...
+
+  l4-group-b:
+    needs: gate-tests
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build binary
+        run: make build
+      - name: Run group-b tests
+        run: |
+          go test -v -timeout 55m -tags="e2e,vm" \
+            -run 'TestVM_Journey_Dotfiles|TestVM_Journey_MacOS|TestVM_Journey_FullSetupConfiguresEverything|TestVM_Edge_|TestSmoke_|TestE2E_' \
+            ./test/e2e/...
+
   build:
-    needs: [detect-release-type, gate-tests]
+    needs: [detect-release-type, gate-tests, l4-group-a, l4-group-b]
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- Adds `l4-group-a` and `l4-group-b` jobs to `release.yml`, mirroring the test split in `vm-e2e-spike.yml`
- Both jobs run on `macos-14` in parallel after `gate-tests` (L1) passes
- `build` job now depends on all three gates: `gate-tests`, `l4-group-a`, `l4-group-b`
- L4 failures block release artifacts from being built and published

## Test plan

- [ ] Verify the workflow YAML is valid (CI will lint it)
- [ ] After merge, push a test tag and confirm L4 jobs appear in the release run