### PR TITLE
ci(test): consolidate L4 into one job and demote publish tests to L3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Unit tests
         run: make test-unit
 
-  l4-group-a:
+  l4:
     needs: gate-tests
     runs-on: macos-14
     timeout-minutes: 60
@@ -76,32 +76,14 @@ jobs:
           cache: true
       - name: Build binary
         run: make build
-      - name: Run group-a tests
+      - name: Run L4 vm tests
         run: |
           go test -v -timeout 55m -tags="e2e,vm" \
-            -run 'TestVM_Journey_FirstTimeUser|TestVM_Journey_DryRunIsCompletelySafe|TestVM_Interactive_InstallScript' \
-            ./test/e2e/...
-
-  l4-group-b:
-    needs: gate-tests
-    runs-on: macos-14
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      - name: Build binary
-        run: make build
-      - name: Run group-b tests
-        run: |
-          go test -v -timeout 55m -tags="e2e,vm" \
-            -run 'TestVM_Journey_Dotfiles|TestVM_Journey_MacOS|TestVM_Journey_FullSetupConfiguresEverything|TestVM_Edge_|TestSmoke_|TestE2E_' \
+            -run 'TestVM_' \
             ./test/e2e/...
 
   build:
-    needs: [detect-release-type, gate-tests, l4-group-a, l4-group-b]
+    needs: [detect-release-type, gate-tests, l4]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/vm-e2e-spike.yml
+++ b/.github/workflows/vm-e2e-spike.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Group A: long-running journey tests that install packages and modify system state.
-  group-a:
+  l4:
     runs-on: macos-14
     timeout-minutes: 60
     steps:
@@ -21,29 +20,8 @@ jobs:
       - name: Build binary
         run: make build
 
-      - name: Run group-a tests
+      - name: Run L4 vm tests
         run: |
           go test -v -timeout 55m -tags="e2e,vm" \
-            -run 'TestVM_Journey_FirstTimeUser|TestVM_Journey_DryRunIsCompletelySafe|TestVM_Interactive_InstallScript' \
-            ./test/e2e/...
-
-  # Group B: dotfiles, macOS defaults, edge cases, sync, and non-destructive e2e.
-  group-b:
-    runs-on: macos-14
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Build binary
-        run: make build
-
-      - name: Run group-b tests
-        run: |
-          go test -v -timeout 55m -tags="e2e,vm" \
-            -run 'TestVM_Journey_Dotfiles|TestVM_Journey_MacOS|TestVM_Journey_FullSetupConfiguresEverything|TestVM_Edge_|TestSmoke_|TestE2E_' \
+            -run 'TestVM_' \
             ./test/e2e/...

--- a/test/e2e/publish_import_e2e_test.go
+++ b/test/e2e/publish_import_e2e_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e && !vm
 
 package e2e
 

--- a/test/e2e/sync_shell_e2e_test.go
+++ b/test/e2e/sync_shell_e2e_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/openbootdotdev/openboot/testutil"
 )
 
-// TestE2E_Sync_Shell_CaptureShell verifies that CaptureShell works correctly
+// TestVM_Sync_Shell_CaptureShell verifies that CaptureShell works correctly
 // in a real macOS environment: detects Oh-My-Zsh and reads theme/plugins from .zshrc.
-func TestE2E_Sync_Shell_CaptureShell(t *testing.T) {
+func TestVM_Sync_Shell_CaptureShell(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping VM test in short mode")
 	}
@@ -43,9 +43,9 @@ func TestE2E_Sync_Shell_CaptureShell(t *testing.T) {
 	assert.NoError(t, err, "~/.oh-my-zsh should exist after install")
 }
 
-// TestE2E_Sync_Shell_NoPanic verifies that the binary handles a remote config
+// TestVM_Sync_Shell_NoPanic verifies that the binary handles a remote config
 // with shell settings without panicking.
-func TestE2E_Sync_Shell_NoPanic(t *testing.T) {
+func TestVM_Sync_Shell_NoPanic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping VM test in short mode")
 	}


### PR DESCRIPTION
## Summary

- Merge `l4-group-a` + `l4-group-b` into a single `l4` job in `release.yml`; `-run` pattern simplified to `TestVM_` (all VM tests share that prefix)
- Same consolidation applied to `vm-e2e-spike.yml`
- `publish_import_e2e_test.go`: add `!vm` constraint — these tests only need a compiled binary + `httptest` mock server, no real macOS VM

## Test plan

- [ ] CI green on this PR
- [ ] After merge, push a tag and confirm only one `l4` job appears in the release run