### PR TITLE
ci: rename l4 job to vm-e2e in release and spike workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Unit tests
         run: make test-unit
 
-  l4:
+  vm-e2e:
     needs: gate-tests
     runs-on: macos-14
     timeout-minutes: 60
@@ -76,14 +76,14 @@ jobs:
           cache: true
       - name: Build binary
         run: make build
-      - name: Run L4 vm tests
+      - name: Run vm e2e tests
         run: |
           go test -v -timeout 55m -tags="e2e,vm" \
             -run 'TestVM_' \
             ./test/e2e/...
 
   build:
-    needs: [detect-release-type, gate-tests, l4]
+    needs: [detect-release-type, gate-tests, vm-e2e]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/vm-e2e-spike.yml
+++ b/.github/workflows/vm-e2e-spike.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  l4:
+  vm-e2e:
     runs-on: macos-14
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary

- Rename the `l4` job to `vm-e2e` in both `release.yml` and `vm-e2e-spike.yml`
- `l4` is an internal tier label that means nothing in the GitHub Actions UI; `vm-e2e` is self-describing

## Test plan

- [ ] CI green
- [ ] After merge, push a tag and confirm the job shows as `vm-e2e` in the release run