### PR TITLE
test(e2e): fix trivial vm assertions and force fresh oh-my-zsh installs

### DIFF
--- a/test/e2e/sync_shell_e2e_test.go
+++ b/test/e2e/sync_shell_e2e_test.go
@@ -20,6 +20,9 @@ func TestVM_Sync_Shell_CaptureShell(t *testing.T) {
 	}
 
 	vm := testutil.NewMacHost(t)
+	// Remove any pre-existing oh-my-zsh so installOhMyZsh actually runs the
+	// install script rather than skipping via the idempotency guard.
+	vm.Run("rm -rf ~/.oh-my-zsh")
 	installOhMyZsh(t, vm)
 	bin := vmCopyDevBinary(t, vm)
 
@@ -38,6 +41,9 @@ func TestVM_Sync_Shell_CaptureShell(t *testing.T) {
 	snapshotOut, err := vmRunDevBinary(t, vm, bin, "snapshot --json")
 	require.NoError(t, err, "snapshot should succeed, output: %s", snapshotOut)
 	assert.NotEmpty(t, snapshotOut)
+	// Snapshot must capture the shell config we set — not just return empty JSON.
+	assert.Contains(t, snapshotOut, "agnoster", "snapshot JSON should capture the zsh theme")
+	assert.Contains(t, snapshotOut, "docker", "snapshot JSON should capture the zsh plugins")
 
 	_, err = vm.Run("test -d ~/.oh-my-zsh")
 	assert.NoError(t, err, "~/.oh-my-zsh should exist after install")
@@ -51,6 +57,9 @@ func TestVM_Sync_Shell_NoPanic(t *testing.T) {
 	}
 
 	vm := testutil.NewMacHost(t)
+	// Remove any pre-existing oh-my-zsh so installOhMyZsh actually runs the
+	// install script rather than skipping via the idempotency guard.
+	vm.Run("rm -rf ~/.oh-my-zsh")
 	installOhMyZsh(t, vm)
 	bin := vmCopyDevBinary(t, vm)
 

--- a/test/e2e/vm_edge_cases_test.go
+++ b/test/e2e/vm_edge_cases_test.go
@@ -30,6 +30,9 @@ func TestVM_Edge_ShellActuallyWorks(t *testing.T) {
 
 	vm := testutil.NewMacHost(t)
 	vmInstallHomebrew(t, vm)
+	// Remove any pre-existing oh-my-zsh so openboot's shell install actually
+	// runs the installer rather than finding it already present.
+	vm.Run("rm -rf ~/.oh-my-zsh")
 	bin := vmCopyDevBinary(t, vm)
 
 	// Install with shell setup

--- a/test/e2e/vm_user_journey_test.go
+++ b/test/e2e/vm_user_journey_test.go
@@ -57,9 +57,35 @@ func TestVM_Journey_FirstTimeUser(t *testing.T) {
 
 	// Step 3: Run openboot with minimal preset
 	t.Run("minimal_preset_installs_usable_tools", func(t *testing.T) {
+		// Snapshot brew formulae before so we can assert openboot actually managed them.
+		beforeFormulae := vmBrewList(t, vm)
+
 		output, err := vmRunDevBinaryWithGit(t, vm, bin, "install --preset minimal --silent --packages-only")
 		t.Logf("install output:\n%s", output)
 		require.NoError(t, err, "minimal preset should succeed")
+
+		afterFormulae := vmBrewList(t, vm)
+
+		// Log the diff for debugging.
+		beforeSet := make(map[string]bool, len(beforeFormulae))
+		for _, f := range beforeFormulae {
+			beforeSet[f] = true
+		}
+		var newlyInstalled []string
+		for _, f := range afterFormulae {
+			if !beforeSet[f] {
+				newlyInstalled = append(newlyInstalled, f)
+			}
+		}
+		t.Logf("newly installed formulae: %v", newlyInstalled)
+
+		// All minimal preset formulae must be tracked by brew after install.
+		// Binary name → formula name: rg → ripgrep; all others match.
+		minimalFormulae := []string{"jq", "ripgrep", "fd", "bat", "fzf", "htop", "tree", "gh"}
+		for _, formula := range minimalFormulae {
+			assert.Contains(t, afterFormulae, formula,
+				"openboot must ensure %s is brew-managed after install", formula)
+		}
 
 		// User expectation: every tool should be USABLE, not just "in PATH"
 		toolChecks := map[string]string{


### PR DESCRIPTION
## Summary

- `TestVM_Journey_FirstTimeUser`: capture `brew list` before/after install; assert all minimal preset formulae (`jq`, `ripgrep`, `fd`, `bat`, `fzf`, `htop`, `tree`, `gh`) are brew-managed after install; log newly installed diff for debugging. Previously the test passed trivially on GHA runners that have these tools pre-installed.
- `TestVM_Sync_Shell_CaptureShell` / `TestVM_Sync_Shell_NoPanic`: `rm -rf ~/.oh-my-zsh` before `installOhMyZsh` so the install script actually runs instead of hitting the idempotency guard.
- `TestVM_Sync_Shell_CaptureShell`: assert snapshot JSON contains the configured theme (`agnoster`) and plugin (`docker`), not just that output is non-empty.
- `TestVM_Edge_ShellActuallyWorks`: `rm -rf ~/.oh-my-zsh` so openboot's shell install exercises the real code path.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, push a tag and confirm vm-e2e job logs show the brew list diff and newly installed formulae