### PR TITLE
test(e2e): uninstall preset packages before FirstTimeUser, remove interactive skip

### DIFF
--- a/test/e2e/vm_interactive_test.go
+++ b/test/e2e/vm_interactive_test.go
@@ -20,19 +20,7 @@ func TestVM_Interactive_InstallScript(t *testing.T) {
 	}
 
 	vm := testutil.NewMacHost(t)
-
-	// This test exercises install.sh's reinstall prompt, which requires openboot
-	// to be registered with Homebrew (`brew list openboot`). Skip if the formula
-	// isn't available — that means we're in a pre-release CI environment where
-	// the tap has no published formula yet.
-	tapScript := fmt.Sprintf(
-		"export PATH=%q && brew tap openbootdotdev/openboot 2>/dev/null; brew info openboot &>/dev/null",
-		brewPath,
-	)
-	if _, err := vm.Run(tapScript); err != nil {
-		t.Skip("openboot Homebrew formula not available — skipping brew-dependent interactive test")
-	}
-	vmInstallViaBrew(t, vm) // Install first (no TTY required)
+	vmInstallViaBrew(t, vm) // taps openbootdotdev/openboot and installs openboot
 
 	// expect is required for interactive tests.
 	if _, err := vm.Run(fmt.Sprintf("export PATH=%q && command -v expect", brewPath)); err != nil {

--- a/test/e2e/vm_user_journey_test.go
+++ b/test/e2e/vm_user_journey_test.go
@@ -14,6 +14,7 @@
 package e2e
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -40,6 +41,12 @@ func TestVM_Journey_FirstTimeUser(t *testing.T) {
 
 	vm := testutil.NewMacHost(t)
 	vmInstallHomebrew(t, vm)
+	// Uninstall the minimal preset packages so openboot actually installs them
+	// rather than finding them pre-installed on the GHA runner image.
+	vm.Run(fmt.Sprintf(
+		"export PATH=%q && brew uninstall --ignore-dependencies jq ripgrep fd bat fzf htop tree gh 2>/dev/null || true",
+		brewPath,
+	))
 	bin := vmCopyDevBinary(t, vm)
 
 	// Step 1: openboot shouldn't leak in from a prior step.


### PR DESCRIPTION
## Summary

- `TestVM_Journey_FirstTimeUser`: `brew uninstall` the 8 minimal preset packages before running install so openboot actually installs them. Previously `newly installed formulae: []` every run because the GHA runner image has them pre-installed.
- `TestVM_Interactive_InstallScript`: remove the `brew info openboot` skip guard. `vmInstallViaBrew` already taps and installs — if the formula is unavailable the test now fails hard instead of silently skipping.

## Test plan

- [ ] CI green
- [ ] After merge, trigger `vm-e2e-spike` manually and confirm `newly installed formulae:` is non-empty in FirstTimeUser logs, and Interactive no longer shows SKIP