### PR TITLE
fix(test): correct brew tap name in vmInstallViaBrew

### DIFF
--- a/test/e2e/vm_helpers_test.go
+++ b/test/e2e/vm_helpers_test.go
@@ -24,7 +24,7 @@ func vmInstallViaBrew(t *testing.T, vm *testutil.MacHost) string {
 
 	script := strings.Join([]string{
 		fmt.Sprintf("export PATH=%q", brewPath),
-		"brew tap openbootdotdev/openboot 2>/dev/null || true",
+		"brew tap openbootdotdev/tap 2>/dev/null || true",
 		"brew install openboot",
 	}, " && ")
 


### PR DESCRIPTION
## Summary

`vmInstallViaBrew` was tapping `openbootdotdev/openboot` which maps to `github.com/openbootdotdev/homebrew-openboot` — that repo doesn't exist. The actual tap is `openbootdotdev/tap` (maps to `github.com/openbootdotdev/homebrew-tap`).

The `|| true` silenced the failure, so `brew install openboot` then failed with "No available formula". This is why `TestVM_Interactive_InstallScript` was **always** skipping — the old guard checked `brew info openboot` which never found the formula because the tap never actually loaded.

## Test plan

- [ ] CI green
- [ ] After merge, trigger `vm-e2e-spike` and confirm `TestVM_Interactive_InstallScript` runs (not SKIP, not FAIL)