### PR TITLE
fix(test): fix Tcl quoting in RunInteractive and openboot isolation in FirstTimeUser

### DIFF
--- a/test/e2e/vm_user_journey_test.go
+++ b/test/e2e/vm_user_journey_test.go
@@ -41,10 +41,10 @@ func TestVM_Journey_FirstTimeUser(t *testing.T) {
 
 	vm := testutil.NewMacHost(t)
 	vmInstallHomebrew(t, vm)
-	// Uninstall the minimal preset packages so openboot actually installs them
-	// rather than finding them pre-installed on the GHA runner image.
+	// Remove the brew-installed openboot (left by TestVM_Interactive_InstallScript)
+	// and the minimal preset packages so openboot actually installs them.
 	vm.Run(fmt.Sprintf(
-		"export PATH=%q && brew uninstall --ignore-dependencies jq ripgrep fd bat fzf htop tree gh 2>/dev/null || true",
+		"export PATH=%q && brew uninstall --ignore-dependencies openboot jq ripgrep fd bat fzf htop tree gh 2>/dev/null || true",
 		brewPath,
 	))
 	bin := vmCopyDevBinary(t, vm)

--- a/testutil/machost.go
+++ b/testutil/machost.go
@@ -73,7 +73,10 @@ func (h *MacHost) RunInteractive(command string, steps []ExpectStep, timeoutSec 
 
 	var script strings.Builder
 	fmt.Fprintf(&script, "set timeout %d\n", timeoutSec)
-	fmt.Fprintf(&script, "spawn bash -c %s\n", shellescape(command))
+	// Use Tcl quoting so the entire command is a single word.
+	// shellescape produces POSIX single-quote escaping which Tcl's word
+	// splitter does not honour — it splits on whitespace regardless.
+	fmt.Fprintf(&script, "spawn bash -c %s\n", tclBrace(command))
 	for _, step := range steps {
 		fmt.Fprintf(&script, "expect %q\n", step.Expect)
 		fmt.Fprintf(&script, "send %q\n", step.Send)
@@ -104,6 +107,16 @@ func (h *MacHost) CopyFile(src, dst string) error {
 
 func shellescape(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// tclBrace quotes s as a single Tcl word. Uses brace quoting {s} when safe
+// (no unbalanced braces), otherwise falls back to Tcl double-quote escaping.
+func tclBrace(s string) string {
+	if !strings.ContainsAny(s, "{}") {
+		return "{" + s + "}"
+	}
+	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`, `$`, `\$`, `[`, `\[`)
+	return `"` + r.Replace(s) + `"`
 }
 
 func requireEphemeralHost(t *testing.T) {


### PR DESCRIPTION
## Summary

**Fix 1 — `RunInteractive` Tcl quoting (`testutil/machost.go`)**

`shellescape()` produces POSIX single-quote escaping (`'cmd'`), but Tcl does not treat `'` as a quoting character — it splits on whitespace, so `spawn bash -c 'cmd with spaces'` becomes `bash -c 'cmd with` + `spaces'` as separate args. Bash then receives a fragmented script and reports `unexpected EOF while looking for matching quote`.

Fix: replace `shellescape` with `tclBrace` which wraps the command in Tcl brace quotes `{cmd}`, making it a single word with no substitution. Falls back to Tcl double-quote escaping if the command contains `{` or `}`.

**Fix 2 — `TestVM_Journey_FirstTimeUser` isolation (`vm_user_journey_test.go`)**

`TestVM_Interactive_InstallScript` installs `openboot` via `brew install`, leaving `/opt/homebrew/bin/openboot` on the runner. The next test (`FirstTimeUser`) then fails `bare_system_has_no_openboot` because `which openboot` finds it.

Fix: add `openboot` to the `brew uninstall` call at the start of `FirstTimeUser` setup.

## Test plan

- [ ] CI green
- [ ] Trigger `vm-e2e-spike` and confirm `TestVM_Interactive_InstallScript` runs (no SKIP, no FAIL) and `FirstTimeUser` passes