### PR TITLE
fix(sync): route brew installs through InstallWithProgress

### DIFF
--- a/internal/sync/plan.go
+++ b/internal/sync/plan.go
@@ -96,16 +96,23 @@ func Execute(plan *SyncPlan, dryRun bool) (*SyncResult, error) {
 		executeSyncStep(plan.InstallTaps, "taps", func() error {
 			return brew.InstallTaps(plan.InstallTaps, dryRun)
 		}),
-		executeSyncStep(plan.InstallFormulae, "formulae", func() error {
-			return brew.Install(plan.InstallFormulae, dryRun)
-		}),
-		executeSyncStep(plan.InstallCasks, "casks", func() error {
-			return brew.InstallCask(plan.InstallCasks, dryRun)
-		}),
+	}
+	// Run formulae+casks through one shared StickyProgress bar — same flow
+	// the wizard path uses. Skipping this and calling brew.Install /
+	// brew.InstallCask separately would lose the byte-level progress bar.
+	if len(plan.InstallFormulae) > 0 || len(plan.InstallCasks) > 0 {
+		_, _, err := brew.InstallWithProgress(plan.InstallFormulae, plan.InstallCasks, dryRun)
+		step := stepResult{label: "brew", err: err}
+		if err == nil {
+			step.count = len(plan.InstallFormulae) + len(plan.InstallCasks)
+		}
+		installSteps = append(installSteps, step)
+	}
+	installSteps = append(installSteps,
 		executeSyncStep(plan.InstallNpm, "npm", func() error {
 			return npm.Install(plan.InstallNpm, dryRun)
 		}),
-	}
+	)
 	for _, s := range installSteps {
 		if s.err != nil {
 			errs = append(errs, fmt.Errorf("install %s: %w", s.label, s.err))


### PR DESCRIPTION
## Summary

- `openboot install` invoked with a saved sync source (the normal "resume last sync" path) was going through `sync.Execute` → bare `brew.Install` / `brew.InstallCask`, which pipes brew's raw non-TTY output straight through. Result: no StickyProgress bar, no byte-level cask download tracking — same binary as curl|bash but visibly different UX.
- Wizard path (curl|bash, first-time install) uses `brew.InstallWithProgress` and renders the bar correctly. This PR unifies the two paths by routing the sync flow's formulae+casks through the same call.
- Tap and npm steps stay separate (different package managers, different concerns). Dry-run counts preserved: `len(formulae) + len(casks)` on success, `0` on early error — matches the existing `executeSyncStep` semantic and keeps `test/integration/sync_integration_test.go` passing unchanged.

## Test plan

- [x] `go vet ./...` — clean
- [x] `make test-unit` — full L1 passes (including `TestIntegration_Execute_DryRun_*` which assert per-step install counts)
- [ ] Manual: clear a cask's brew cache (`rm -f "$(brew --cache --cask <name>)"*`), run `./openboot install` with a sync source pointing at a config that includes that cask, confirm the StickyProgress bar fills as bytes accumulate