### PR TITLE
fix(progress): always show at least one filled char when progress > 0

### DIFF
--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -168,6 +168,9 @@ func (sp *StickyProgress) renderInline() {
 		pct = float64(sp.completed) / float64(sp.total)
 	}
 	filled := int(pct * float64(sp.barWidth))
+	if pct > 0 && filled == 0 {
+		filled = 1
+	}
 	empty := sp.barWidth - filled
 
 	bar := progressBarStyle.Render(strings.Repeat("█", filled)) +
@@ -217,6 +220,9 @@ func (sp *StickyProgress) formatLines() []string {
 
 	pct := sp.pctForBar()
 	filled := int(pct * float64(barWidth))
+	if pct > 0 && filled == 0 {
+		filled = 1
+	}
 	empty := barWidth - filled
 	bar := progressBarStyle.Render(strings.Repeat("█", filled)) +
 		progressBgStyle.Render(strings.Repeat("░", empty))


### PR DESCRIPTION
## Summary

- During formula installs with many large casks queued, the byte-proportional bar stays near 1% — `int(0.01 * 40 chars) == 0` so zero green characters render and the bar looks absent
- Fix: if `pct > 0` and `filled` rounds to 0, clamp it to 1 so the green indicator is always visible once any work has started
- Applied to both `formatLines()` (scroll-region path) and `renderInline()` (fallback path)

## Test plan

- [ ] Existing `TestStickyProgress*` suite passes (`go test ./internal/ui/...`)
- [ ] Manual: run `openboot install` with a config that has many large casks; green bar is visible even at 1% during formula phase