### PR TITLE
fix(brew): suppress cask stdout/stderr during install

### DIFF
--- a/internal/archtest/baseline/no-direct-exec.txt
+++ b/internal/archtest/baseline/no-direct-exec.txt
@@ -2,7 +2,7 @@
 # Each line is <file>:<line> of a known existing violation.
 # Regenerate: ARCHTEST_UPDATE_BASELINE=1 go test ./internal/archtest/...
 internal/auth/login.go:191
-internal/brew/brew_install.go:337
+internal/brew/brew_install.go:328
 internal/cli/snapshot.go:21
 internal/diff/compare.go:247
 internal/diff/compare.go:253

--- a/internal/brew/brew_install.go
+++ b/internal/brew/brew_install.go
@@ -186,13 +186,11 @@ func InstallWithProgress(cliPkgs, caskPkgs []string, dryRun bool) (installedForm
 	return installedFormulae, installedCasks, nil
 }
 
-// installCasksWithProgress installs cask packages one by one, letting brew's
-// own output (download progress, etc.) scroll through. Returns successful
-// installs and failed jobs.
+// installCasksWithProgress installs cask packages one by one with brew output
+// suppressed. Returns successful installs and failed jobs.
 func installCasksWithProgress(pkgs []string, progress *ui.StickyProgress) (installed []string, failed []failedJob) {
 	for _, pkg := range pkgs {
 		progress.SetCurrent(pkg)
-		progress.PrintLine("  Installing %s...", pkg)
 
 		start := time.Now()
 		errMsg := installCaskWithProgress(pkg)
@@ -313,18 +311,11 @@ func runSerialInstallWithProgress(pkgs []string, progress *ui.StickyProgress) []
 }
 
 func installCaskWithProgress(pkg string) string {
-	cmd := brewInstallCmd("install", "--cask", pkg)
-	tty, opened := system.OpenTTY()
-	if opened {
-		defer tty.Close() //nolint:errcheck // best-effort TTY cleanup
+	output, err := brewCombinedOutputWithTTY("install", "--cask", pkg)
+	if err == nil {
+		return ""
 	}
-	cmd.Stdin = tty
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return "install failed"
-	}
-	return ""
+	return parseBrewError(output)
 }
 
 // Runner-exempt: this helper sets HOMEBREW_NO_AUTO_UPDATE=1 and returns a raw


### PR DESCRIPTION
## Summary

- Remove pre-install \`Installing X...\` PrintLine for casks
- Switch \`installCaskWithProgress\` from transparent stdout/stderr to \`brewCombinedOutputWithTTY\` — same approach as formula installs
- Error strings now parsed via \`parseBrewError\` instead of bare \`"install failed"\`

## Motivation

Formula and cask installs now use one unified voice: our own \`✔ pkg (Xs)\` / \`✗ pkg (error)\` completion lines, spinner + elapsed in the sticky bar. No more brew verbose output interleaved with our UI messages.

## Test plan

- [x] \`go test ./internal/brew/...\` passes
- [x] \`go vet ./...\` clean