### PR TITLE
fix(config): allow '+' in package and cask names

### DIFF
--- a/internal/config/types_extra_test.go
+++ b/internal/config/types_extra_test.go
@@ -133,6 +133,16 @@ func TestRemoteConfig_WithValidPackages(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// Homebrew casks can contain '+' (e.g. logi-options+, gtk+). See issue #101.
+func TestRemoteConfig_AllowsPlusInPackageNames(t *testing.T) {
+	rc := &RemoteConfig{
+		Packages: PackageEntryList{{Name: "gtk+"}},
+		Casks:    PackageEntryList{{Name: "logi-options+"}},
+	}
+	err := rc.Validate()
+	assert.NoError(t, err)
+}
+
 func TestRemoteConfig_InvalidPackageName(t *testing.T) {
 	rc := &RemoteConfig{
 		Packages: PackageEntryList{{Name: "bad name with spaces"}},

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -13,7 +13,7 @@ const (
 )
 
 var (
-	pkgNameRe = regexp.MustCompile(`^[a-zA-Z0-9@/_.-]+$`)
+	pkgNameRe = regexp.MustCompile(`^[a-zA-Z0-9@/_.+-]+$`)
 	tapNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$`)
 	// macOS preference domains never contain spaces; keys may (e.g. "NSStatusItem Visible Sound").
 	domainRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)


### PR DESCRIPTION
## Summary

- Adds `+` to `pkgNameRe` so Homebrew casks like `logi-options+` and formulae like `gtk+` validate.
- Adds a regression test (`TestRemoteConfig_AllowsPlusInPackageNames`).

Without this, `openboot snapshot --publish` fails for users whose machine has any cask containing `+`. The server returns a 400 (`Only alphanumeric, hyphens, underscores, dots, @ and / allowed.`), but the CLI's own regex is identical — so the same input would be rejected once client-side validation is wired in too.

Server-side validation needs the matching relaxation in a separate PR on the openboot.dev repo.

Fixes #101

## Test plan

- [x] `go test -run TestRemoteConfig_AllowsPlusInPackageNames ./internal/config/` — failed before the regex change, passes after.
- [x] `make test-unit` — full L1 green.
- [x] `go vet ./...`