### PR TITLE
fix: propagate brew errors, replace raw Scanln, remove sudo rm -rf

### DIFF
--- a/internal/archtest/baseline/fmtprint.txt
+++ b/internal/archtest/baseline/fmtprint.txt
@@ -113,12 +113,11 @@ internal/installer/step_packages.go:77
 internal/installer/step_packages.go:83
 internal/installer/step_packages.go:134
 internal/installer/step_packages.go:139
-internal/installer/step_packages.go:159
-internal/installer/step_packages.go:205
+internal/installer/step_packages.go:161
 internal/installer/step_packages.go:207
 internal/installer/step_packages.go:209
-internal/installer/step_packages.go:227
-internal/installer/step_packages.go:228
+internal/installer/step_packages.go:211
+internal/installer/step_packages.go:229
 internal/installer/step_shell.go:17
 internal/installer/step_shell.go:40
 internal/installer/step_shell.go:58

--- a/internal/brew/brew.go
+++ b/internal/brew/brew.go
@@ -275,7 +275,7 @@ func DoctorDiagnose() ([]string, error) {
 	lowerOutput := strings.ToLower(outputStr)
 
 	if strings.Contains(lowerOutput, "unbrewed header files") {
-		suggestions = append(suggestions, "Run: sudo rm -rf /usr/local/include")
+		suggestions = append(suggestions, "Run: brew doctor --list-checks (review unbrewed header files before removing)")
 	}
 	if strings.Contains(lowerOutput, "unbrewed dylibs") {
 		suggestions = append(suggestions, "Run: brew doctor --list-checks and review linked libraries")
@@ -296,7 +296,7 @@ func DoctorDiagnose() ([]string, error) {
 		suggestions = append(suggestions, "Run: brew update-reset")
 	}
 	if strings.Contains(lowerOutput, "permission") {
-		suggestions = append(suggestions, "Run: sudo chown -R $(whoami) $(brew --prefix)/*")
+		suggestions = append(suggestions, "Run: brew doctor (review permission warnings before changing ownership)")
 	}
 
 	if len(suggestions) == 0 && !strings.Contains(outputStr, "ready to brew") {

--- a/internal/brew/brew_command_test.go
+++ b/internal/brew/brew_command_test.go
@@ -99,7 +99,7 @@ func TestDoctorDiagnose_Suggestions(t *testing.T) {
 
 	suggestions, err := DoctorDiagnose()
 	require.NoError(t, err)
-	assert.Contains(t, suggestions, "Run: sudo rm -rf /usr/local/include")
+	assert.Contains(t, suggestions, "Run: brew doctor --list-checks (review unbrewed header files before removing)")
 	assert.Contains(t, suggestions, "Run: brew cleanup --prune=all")
 }
 
@@ -238,7 +238,7 @@ Warning: permission issues
 	assert.Contains(t, suggestions, "Run: brew update-reset")
 	assert.Contains(t, suggestions, "Run: xcode-select --install")
 	assert.Contains(t, suggestions, "Run: brew cleanup --prune=all")
-	assert.Contains(t, suggestions, "Run: sudo chown -R $(whoami) $(brew --prefix)/*")
+	assert.Contains(t, suggestions, "Run: brew doctor (review permission warnings before changing ownership)")
 }
 
 func TestDoctorDiagnose_UnknownWarnings(t *testing.T) {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -84,11 +84,11 @@ func Apply(plan InstallPlan, r Reporter) error {
 		}
 	}
 
-	if err := applyPackages(plan, r); err != nil {
-		return err
-	}
-
 	var softErrs []error
+
+	if err := applyPackages(plan, r); err != nil {
+		softErrs = append(softErrs, fmt.Errorf("brew: %w", err))
+	}
 
 	if err := applyNpm(plan, r); err != nil {
 		r.Error(fmt.Sprintf("npm package installation failed: %v", err))

--- a/internal/installer/step_packages.go
+++ b/internal/installer/step_packages.go
@@ -3,13 +3,13 @@ package installer
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/openbootdotdev/openboot/internal/brew"
 	"github.com/openbootdotdev/openboot/internal/config"
 	"github.com/openbootdotdev/openboot/internal/npm"
 	"github.com/openbootdotdev/openboot/internal/system"
+	"github.com/openbootdotdev/openboot/internal/ui"
 )
 
 type categorizedPackages struct {
@@ -154,10 +154,12 @@ func applyPackages(plan InstallPlan, r Reporter) error { //nolint:gocyclo // orc
 				r.Warn(fmt.Sprintf("Failed to track installed package %s: %v", pkg, err))
 			}
 		}
-		r.Success("Package installation complete")
+		if brewErr == nil {
+			r.Success("Package installation complete")
+		}
 	}
 	fmt.Println()
-	return nil
+	return brewErr
 }
 
 func applyNpm(plan InstallPlan, r Reporter) error { //nolint:gocyclo // handles npm batch + sequential fallback with per-package error tracking
@@ -225,10 +227,8 @@ func applyNpm(plan InstallPlan, r Reporter) error { //nolint:gocyclo // handles 
 			continue
 		}
 		fmt.Println()
-		fmt.Printf("  Retry npm installation? [Y/n] ")
-		var response string
-		fmt.Scanln(&response) //nolint:errcheck,gosec // interactive prompt; empty input is valid
-		if strings.ToLower(strings.TrimSpace(response)) == "n" || strings.ToLower(strings.TrimSpace(response)) == "no" {
+		retry, err := ui.Confirm("Retry npm installation?", true)
+		if err != nil || !retry {
 			r.Muted("Skipping npm package retry")
 			return lastErr
 		}


### PR DESCRIPTION
## Summary

- **brew error propagation complete**: `applyPackages` now returns `brewErr` to `Apply()`, which collects it as a soft error. Previously the error was logged via `r.Error()` but `return nil` meant `Apply()` reported 0 errors and showed "Installation Complete!" even when packages failed. Now completion correctly shows "finished with errors" and the final error includes the brew failure.
- **`fmt.Scanln` → `ui.Confirm`**: npm retry prompt replaced with `ui.Confirm("Retry npm installation?", true)` for consistency — every other interactive prompt in the codebase uses `ui.*` helpers.
- **`DoctorDiagnose` safe suggestions**: removed `sudo rm -rf /usr/local/include` and `sudo chown -R $(whoami) $(brew --prefix)/*` suggestions. Replaced with guidance to review `brew doctor` output before taking action. These suggestions were based on string-matching brew's unstable human-readable output — a false match could destroy the user's toolchain.

## Test plan

- [x] `go test ./internal/...` — all 21 packages pass
- [x] `go vet ./...` — clean
- [x] Archtest baseline regenerated (fmtprint.txt updated for removed `fmt.Scanln` + `fmt.Printf`)
- [x] `TestDoctorDiagnose_Suggestions` and `TestDoctorDiagnose_MultipleWarnings` updated to match new safe suggestion text