### PR TITLE
feat: add dry-run archtest rule to enforce DryRun checks before destructive ops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ update the baseline — do not silence the rule.
 | Use `os.UserHomeDir()` — never `os.Getenv("HOME")` | `internal/archtest/envhome_test.go` |
 | Error wrapping with `%w`, no bare returns | reviewer + `errcheck` (golangci-lint) |
 | UI output via `ui.*` helpers — never raw `fmt.Println` in user-facing paths | reviewer (planned: archtest rule) |
-| Destructive ops check `cfg.DryRun` before acting | reviewer (planned: archtest rule) |
+| Destructive ops check `cfg.DryRun` before acting | `internal/archtest/dryrun_test.go` |
 
 The full convention list lives in CLAUDE.md → "Project-specific conventions".
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Bolded rules are enforced mechanically by `internal/archtest` (fitness functions
 - **Error wrapping**: `fmt.Errorf("context: %w", err)` — never bare returns.
 - **UI output**: always through `ui.*` helpers; raw `fmt.Println` is a bug in user-facing paths.
 - **Subprocess** *(archtest: `no-direct-exec`)*: `system.RunCommand` (interactive) / `system.RunCommandSilent` (captured). Do not call `exec.Command` directly from feature code — add to `system/` if a wrapper is missing.
-- **Destructive ops**: check `cfg.DryRun` first. Always.
+- **Destructive ops** *(archtest: `dryrun`)*: check `cfg.DryRun` first. Always.
 - **Paths** *(archtest: `no-os-getenv-home`)*: `os.UserHomeDir()` — never hardcode `~` or `/Users/...`, never `os.Getenv("HOME")`.
 - **State**: everything user-local goes under `~/.openboot/` (auth, cache, snapshots, state).
 - **Concurrency**: bounded `sync.WaitGroup` — brew install is sequential with retry; `GetInstalledPackages` uses 2 goroutines for formula+cask list. No unbounded goroutines.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -45,6 +45,7 @@ Three regulation categories:
 | Arch. | `no-direct-exec` | L1 (`make test-unit`) | `internal/archtest/exec_test.go` |
 | Arch. | `no-raw-http` | L1 | `internal/archtest/http_test.go` |
 | Arch. | `no-os-getenv-home` | L1 | `internal/archtest/envhome_test.go` |
+| Arch. | `dryrun` — destructive ops must check `DryRun` | L1 | `internal/archtest/dryrun_test.go` |
 | Behav. | L1 unit + integration + contract (faked runners *and* real brew/git/npm in temp dirs) | pre-push, CI | `make test-unit` |
 | Behav. | L2 contract schema (against openboot-contract repo) | CI | `.github/workflows/test.yml` `contract` job |
 | Behav. | L3 e2e binary | release | `make test-e2e` |

--- a/internal/archtest/README.md
+++ b/internal/archtest/README.md
@@ -28,6 +28,7 @@ from the baseline) are logged but do not fail the test.
 | `no-direct-exec` | `exec_test.go` | yes | "Do not call `exec.Command` directly from feature code" |
 | `no-raw-http` | `http_test.go` | yes | "Use `httputil.Do()` — handles 429 + Retry-After" |
 | `no-os-getenv-home` | `envhome_test.go` | no (hard rule) | "Use `os.UserHomeDir()` — never hardcode `~` or `/Users/...`" |
+| `dryrun` | `dryrun_test.go` | yes | "Destructive ops: check `cfg.DryRun` first. Always." |
 
 ## Workflow
 

--- a/internal/archtest/baseline/dryrun.txt
+++ b/internal/archtest/baseline/dryrun.txt
@@ -1,0 +1,26 @@
+# Baseline for archtest rule "dryrun".
+# Each line is <file>:<line> of a known existing violation.
+# Regenerate: ARCHTEST_UPDATE_BASELINE=1 go test ./internal/archtest/...
+internal/dotfiles/dotfiles.go:260
+internal/dotfiles/dotfiles.go:270
+internal/dotfiles/dotfiles.go:327
+internal/shell/shell.go:242
+internal/shell/shell.go:245
+internal/shell/shell.go:246
+internal/snapshot/capture.go:200
+internal/snapshot/capture.go:239
+internal/snapshot/capture.go:269
+internal/snapshot/capture.go:303
+internal/snapshot/capture.go:307
+internal/snapshot/capture.go:335
+internal/snapshot/capture.go:361
+internal/snapshot/local.go:22
+internal/snapshot/local.go:32
+internal/snapshot/local.go:35
+internal/snapshot/local.go:36
+internal/sync/diff.go:275
+internal/sync/source.go:63
+internal/sync/source.go:73
+internal/sync/source.go:76
+internal/sync/source.go:77
+internal/sync/source.go:91

--- a/internal/archtest/dryrun_test.go
+++ b/internal/archtest/dryrun_test.go
@@ -1,0 +1,185 @@
+package archtest
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+)
+
+// dryRunExemptPaths lists packages that are exempt from the dry-run guard
+// rule. These are infrastructure packages where the callers (not the
+// packages themselves) are responsible for checking DryRun.
+var dryRunExemptPaths = []string{
+	"internal/archtest",  // the rules themselves
+	"internal/ui",        // output helpers
+	"internal/logging",   // log file management
+	"internal/state",     // internal state persistence
+	"internal/updater",   // self-update; runs before user commands
+	"internal/system",    // wrappers; callers are responsible for dry-run
+	"internal/httputil",  // network; not destructive to local state
+	"internal/config",    // reads config + writes cache files
+	"internal/auth",      // login/logout; not gated by dry-run by design
+	"cmd/",               // main entry point, not destructive
+}
+
+// dryRunExemptFiles lists individual files exempt from the rule.
+var dryRunExemptFiles = []string{
+	"internal/installer/state.go", // install state tracking
+}
+
+// destructiveOsCalls lists os package functions that modify the filesystem.
+var destructiveOsCalls = []string{
+	"WriteFile",
+	"Remove",
+	"RemoveAll",
+	"Rename",
+	"MkdirAll",
+	"Create",
+	"OpenFile",
+}
+
+// destructiveSystemCalls lists system package functions that run subprocesses.
+var destructiveSystemCalls = []string{
+	"RunCommand",
+	"RunCommandSilent",
+	"RunCommandOutput",
+}
+
+// hasDryRunReference reports whether the function body contains any
+// reference to a variable or field named dryRun or DryRun (case-insensitive
+// prefix match on "dryrun"/"DryRun").
+func hasDryRunReference(fn *ast.FuncDecl) bool {
+	if fn.Body == nil {
+		return false
+	}
+
+	// Check function parameters for dryRun/DryRun.
+	if fn.Type.Params != nil {
+		for _, field := range fn.Type.Params.List {
+			for _, name := range field.Names {
+				low := strings.ToLower(name.Name)
+				if low == "dryrun" {
+					return true
+				}
+			}
+		}
+	}
+
+	// Walk the function body looking for any identifier or selector
+	// referencing dryRun/DryRun.
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch v := n.(type) {
+		case *ast.Ident:
+			low := strings.ToLower(v.Name)
+			if low == "dryrun" {
+				found = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			low := strings.ToLower(v.Sel.Name)
+			if low == "dryrun" {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// findDestructiveWithoutDryRun walks each function declaration in gf and
+// reports functions that contain destructive calls but lack a dryRun/DryRun
+// reference. Each destructive call site inside such a function is reported.
+func findDestructiveWithoutDryRun(gf goFile) []callSite {
+	osLocal := importedAs(gf.file, "os")
+	sysLocal := importedAs(gf.file, "github.com/openbootdotdev/openboot/internal/system")
+
+	var out []callSite
+	for _, decl := range gf.file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if hasDryRunReference(fn) {
+			continue
+		}
+
+		// Collect destructive call sites inside this function.
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+
+			matched := false
+			if osLocal != "" && ident.Name == osLocal {
+				for _, fn := range destructiveOsCalls {
+					if sel.Sel.Name == fn {
+						matched = true
+						break
+					}
+				}
+			}
+			if sysLocal != "" && ident.Name == sysLocal {
+				for _, fn := range destructiveSystemCalls {
+					if sel.Sel.Name == fn {
+						matched = true
+						break
+					}
+				}
+			}
+			if matched {
+				p := gf.fset.Position(call.Pos())
+				out = append(out, callSite{file: gf.path, line: p.Line})
+			}
+			return true
+		})
+	}
+	return out
+}
+
+// TestDryRunGuard enforces the CLAUDE.md rule:
+//
+//	Destructive ops: check cfg.DryRun first. Always.
+//
+// Functions that call destructive operations (system.RunCommand*,
+// os.WriteFile, os.Remove*, os.Rename, os.MkdirAll, os.Create, os.OpenFile)
+// must reference dryRun/DryRun somewhere in their body — either as a
+// parameter or a field access (e.g. cfg.DryRun). Infrastructure packages
+// are exempt; the baseline captures known exceptions.
+func TestDryRunGuard(t *testing.T) {
+	r := rule{
+		name: "dryrun",
+		fix:  "Add a dryRun bool parameter or check cfg.DryRun before calling destructive operations (system.RunCommand*, os.WriteFile, os.Remove, etc.). If this function is infrastructure that doesn't need a dry-run guard, add it to the baseline.",
+	}
+	var violations []callSite
+	for _, gf := range productionFiles(t) {
+		if inAllowedPath(gf.path, dryRunExemptPaths) {
+			continue
+		}
+		exempt := false
+		for _, ef := range dryRunExemptFiles {
+			if gf.path == ef {
+				exempt = true
+				break
+			}
+		}
+		if exempt {
+			continue
+		}
+		violations = append(violations, findDestructiveWithoutDryRun(gf)...)
+	}
+	enforce(t, r, violations)
+}

--- a/internal/archtest/dryrun_test.go
+++ b/internal/archtest/dryrun_test.go
@@ -10,16 +10,16 @@ import (
 // rule. These are infrastructure packages where the callers (not the
 // packages themselves) are responsible for checking DryRun.
 var dryRunExemptPaths = []string{
-	"internal/archtest",  // the rules themselves
-	"internal/ui",        // output helpers
-	"internal/logging",   // log file management
-	"internal/state",     // internal state persistence
-	"internal/updater",   // self-update; runs before user commands
-	"internal/system",    // wrappers; callers are responsible for dry-run
-	"internal/httputil",  // network; not destructive to local state
-	"internal/config",    // reads config + writes cache files
-	"internal/auth",      // login/logout; not gated by dry-run by design
-	"cmd/",               // main entry point, not destructive
+	"internal/archtest", // the rules themselves
+	"internal/ui",       // output helpers
+	"internal/logging",  // log file management
+	"internal/state",    // internal state persistence
+	"internal/updater",  // self-update; runs before user commands
+	"internal/system",   // wrappers; callers are responsible for dry-run
+	"internal/httputil", // network; not destructive to local state
+	"internal/config",   // reads config + writes cache files
+	"internal/auth",     // login/logout; not gated by dry-run by design
+	"cmd/",              // main entry point, not destructive
 }
 
 // dryRunExemptFiles lists individual files exempt from the rule.


### PR DESCRIPTION
## Summary
- New archtest fitness function `dryrun` in `internal/archtest/dryrun_test.go` (185 LOC)
- AST-walks every production function: detects destructive calls (`system.RunCommand*`, `os.WriteFile`, `os.Remove*`, etc.) and verifies the enclosing function references `dryRun`/`DryRun`
- 23 existing violations baselined (dotfiles, shell, snapshot, sync — all read-only or infrastructure writes)
- Updated CLAUDE.md, AGENTS.md, HARNESS.md, archtest README to reflect the new rule
- Promotes "Destructive ops: check DryRun first" from doc convention → mechanical enforcement

## Test plan
- [x] `go test ./internal/archtest/... -run TestDryRunGuard` passes
- [x] `go test ./internal/...` all packages pass
- [x] `go vet ./...` passes