### PR TITLE
refactor: split ui/ into helpers and tui model subpackages

### DIFF
--- a/docs/openboot-linus-code-review.md
+++ b/docs/openboot-linus-code-review.md
@@ -1,0 +1,417 @@
+# OpenBoot — Linus 风格代码评审（第三轮）
+
+> **风格说明：** 以下内容刻意模仿 Linus Torvalds 式的直接批评风格。批评基于技术事实，不针对个人。
+> **代码库版本：** `main @ 2932d6a`（含 PR #102–#106 的全部修复）
+> **分析范围：** 284 个生产 Go 文件，376 个测试文件，~61,300 行生产代码 + ~100,119 行测试代码，24 个内部包，9 个直接依赖
+
+---
+
+## 综合评分
+
+| 维度 | 分数 (0–10) | 说明 |
+|------|:-----------:|------|
+| 架构设计 | **8.5** | 分层清晰，DAG 无环，archtest 强制守护 |
+| 代码质量 | **8.0** | 命名好、一致性强、错误处理扎实，但有少量类型安全和重复问题 |
+| 工程实践 | **9.0** | L1–L4 四层测试、1.6:1 测试代码比、自动发布管线、drift 探测 |
+| 性能与风险 | **8.0** | 并发保守正确、资源清理到位、原子写入，但缺少跨步骤回滚 |
+| **总分** | **8.5 / 10** | |
+| **同类项目水平** | **高** | 在"开发者环境配置 CLI"这个赛道里，这是我见过的工程质量最好的之一 |
+
+---
+
+## 一、架构设计
+
+### 1.1 优点：说真的，这个分层做得很好
+
+```
+cmd/openboot/main.go (25 LOC)
+  └─ cli.Execute()
+       └─ rootCmd (Cobra)
+            ├─ installCmd → installer.Run(cfg)
+            ├─ snapshotCmd → snapshot.*
+            ├─ loginCmd → auth.*
+            └─ ...
+```
+
+**依赖图是严格 DAG，没有环：**
+
+```
+system (叶子节点)
+  ↑
+config, httputil, auth, logging, state, search
+  ↑
+brew, npm, dotfiles, shell, macos, snapshot, sync, diff, updater
+  ↑
+installer (编排器)
+  ↑
+cli (Cobra 命令)
+  ↑
+cmd/openboot/main.go
+```
+
+这不是偶然的。这个项目有 `internal/archtest/` 作为 fitness function，用 AST 分析在 L1 测试阶段就强制守护架构约束。四条规则：
+
+| 规则 | 作用 | 基线违规数 |
+|------|------|:----------:|
+| `no-direct-exec` | `exec.Command` 只能出现在 `system/`、`brew/runner.go`、`npm/runner.go` | 18 |
+| `no-raw-http` | `http.NewRequest` 只能出现在 `httputil/` | 12 |
+| `no-os-getenv-home` | 禁止 `os.Getenv("HOME")`，必须用 `os.UserHomeDir()` | 0（硬规则） |
+| `fmtprint` | 用户可见输出必须走 `ui.*` helpers | 161 |
+
+这种"用测试守护架构"的做法，比写在文档里然后祈祷人类会看要靠谱一万倍。**这是整个代码库最有价值的设计决策之一。**
+
+### 1.2 优点：Plan/Apply 分离
+
+`installer/` 把交互（Plan）和副作用（Apply）分开了：
+
+- **Plan**: 收集用户输入（git config、preset 选择、shell/dotfiles/macOS 偏好）
+- **Apply**: 纯执行，按步骤推进，每步独立失败
+
+这意味着你可以测试 Plan 逻辑而不需要真正安装任何东西，也可以测试 Apply 逻辑而不需要人类在终端前坐着。这是正确的架构。
+
+### 1.3 优点：Runner 接口做得恰到好处
+
+```go
+type Runner interface {
+    Output(args ...string) ([]byte, error)
+    CombinedOutput(args ...string) ([]byte, error)
+    Run(args ...string) error
+    RunInteractive(args ...string) error
+}
+```
+
+不多不少。四个方法覆盖所有子进程场景。测试时注入 `recordingRunner`，生产时用 `execRunner`。这比那些"我要做一个通用的 CommandExecutor 框架"的过度设计好多了。
+
+### 1.4 问题：installer/ 作为上帝编排器的隐患
+
+`installer/` 直接导入了 8 个包：`brew`, `config`, `dotfiles`, `macos`, `npm`, `permissions`, `shell`, `system`, `ui`。
+
+现在 7 步还能管住。但如果你要加到 15 步呢？这个文件会变成一个"什么都知道"的上帝模块。
+
+**改进建议：** 如果步骤增长，考虑一个步骤注册表模式（step registry）。每个步骤实现一个 `Step` 接口，installer 只负责按序调用。不是现在需要做的事，但心里要有数。
+
+### 1.5 问题：ui/ 是最大的包（3,578 LOC），职责开始模糊
+
+`ui/` 里面混了三种东西：
+1. 简单的输出 helpers（`Header()`, `Success()`, `Error()` — 这些很好）
+2. huh 表单封装（`InputGitConfig()`, `SelectPreset()` — 也 OK）
+3. 复杂的 bubbletea Model（`selector.go` 418 LOC, `snapshot_editor.go` 894 LOC）
+
+第三类和前两类不是一个抽象层次。`snapshot_editor.go` 独占 894 行，这不是一个"helper"，这是一个完整的 TUI 应用。
+
+**改进建议：** 拆分成 `ui/helpers/` + `ui/models/`。不是紧急的，但 3,578 行的单包已经接近"我需要花 5 分钟才能找到我要改的东西"的阈值了。
+
+---
+
+## 二、代码质量
+
+### 2.1 优点：错误处理几乎是教科书级的
+
+整个代码库有 **228 处 `fmt.Errorf` 带 `%w`**，只有 **49 处裸 `return err`**。这个比例（82% 包装率）在 Go 项目里已经很优秀了。
+
+典型的好例子：
+```go
+// internal/brew/brew.go
+return nil, fmt.Errorf("list formulae: %w", fErr)
+
+// internal/config/remote.go
+return nil, fmt.Errorf("create request: %w", err)
+
+// internal/system/system.go
+return "", fmt.Errorf("home dir: %w", err)
+```
+
+每个错误都带上下文。当你在日志里看到 `list formulae: exit status 1` 时，你立刻知道是 `brew list --formula` 挂了，而不是某个不知名的函数返回了一个 `exit status 1`。**这就是错误处理该有的样子。**
+
+### 2.2 优点：命名一致且自解释
+
+- 导出函数：`GetInstalledPackages()`, `ListOutdated()`, `CheckDiskSpace()`, `ConfigureGit()`
+- 未导出函数：`applyEnvOverrides()`, `checkDependencies()`, `assembleSnapshot()`
+- 类型名：`InstallOptions`, `InstallState`, `RemoteConfig`, `StickyProgress`
+
+没有 `doStuff()`, 没有 `handleThing()`, 没有单字母变量名（除了循环变量）。这在 Go 社区是基本要求，但你会惊讶于有多少项目做不到。
+
+### 2.3 优点：几乎没有死代码
+
+我没有发现注释掉的代码块、未使用的导出函数、或"以防万一"的 dead path。CI 里还有 `deadcode` 工具在 `harness.yml` 中做信息性扫描。这说明代码库是被积极维护的，而不是"写完就不管了"。
+
+### 2.4 问题：`interface{}` 在 snapshot capture 里是个设计缺陷
+
+```go
+// internal/snapshot/capture.go
+var captureStep struct {
+    name    string
+    capture func() (interface{}, error)
+    count   func(interface{}) int
+}
+
+// 后面：
+formulae, _ := results[0].([]string)
+casks, _ := results[1].([]string)
+```
+
+**这就是在用 `interface{}` 假装自己不需要类型系统。**
+
+问题不只是"不够优雅"。如果有人调换了 `captureSteps` 的顺序，`results[0].([]string)` 会默默返回零值而不是 panic。你甚至不知道出了什么问题，直到用户报告"为什么我的 snapshot 丢了所有 casks"。
+
+**Go 有泛型了（1.18+）。用它。** 或者更简单：定义一个 `CaptureResults` 结构体，每个字段有类型。
+
+```go
+type CaptureResults struct {
+    Formulae []string
+    Casks    []string
+    Taps     []string
+    // ...
+}
+```
+
+这不是建议，这是 bug 等着发生。
+
+### 2.5 问题：dry-run 模式的代码重复
+
+整个代码库有 ~43 处这样的模式：
+
+```go
+if dryRun {
+    ui.Info("Would uninstall...")
+    for _, p := range packages {
+        fmt.Printf("    brew uninstall %s\n", p)
+    }
+    return nil
+}
+```
+
+`Uninstall()`, `UninstallCask()`, `Untap()`, `Install()`, `InstallCask()` — 每个都有几乎一模一样的 dry-run 守卫。
+
+**三个相似的地方是模式，四十三个相似的地方是复制粘贴。**
+
+**改进建议：** 提取一个 `dryRunGuard(action string, items []string)` helper。一个函数替换 43 处重复。
+
+### 2.6 轻微问题：少数裸 `return err`
+
+`internal/macos/macos.go`, `internal/dotfiles/dotfiles.go`, `internal/updater/updater.go` 中有少量裸 `return err`。在一个 82% 包装率的代码库里，这些不一致格外扎眼。
+
+不是严重问题，但如果你号称"所有错误必须包装"，那就别留例外。
+
+---
+
+## 三、工程实践
+
+### 3.1 优点：这可能是我见过的测试做得最认真的 CLI 项目
+
+**测试代码量是生产代码的 1.6 倍。** 376 个测试文件对 284 个生产文件。不是"写了几个测试意思一下"，是真的在认真测试。
+
+四层测试策略：
+
+| 层级 | 范围 | 运行时机 | 耗时 |
+|------|------|---------|------|
+| L1 | 单元 + 集成 + 合约（faked Runner） | pre-push hook, CI | ~75s |
+| L2 | 合约 schema 验证 | CI（仅 main） | ~10s |
+| L3 | 编译后二进制 e2e | CI release | ~60s |
+| L4 | 破坏性 VM e2e（真实 macOS） | CI（macos-14 runner） | ~20min |
+
+L4 尤其值得一提：在 GitHub Actions 的 Apple Silicon macOS 14 runner 上跑真实的 `brew install`、`defaults write`、Oh-My-Zsh 安装。这是"我真的关心这个东西能不能在真机上跑"的态度，不是"单元测试全绿应该没问题吧"的侥幸心理。
+
+### 3.2 优点：CI 管线设计很成熟
+
+```
+PR 推送 → lint + L1 + L4 VM e2e
+main 推送 → 上述 + curl|bash 烟雾测试 + CLI 向后兼容测试 + L2 合约
+打 tag → release.yml: gate-tests + vm-e2e → 构建 darwin amd64/arm64 → 校验和 → Homebrew tap 更新
+```
+
+**自动发布机制值得学习：**
+- `fix:` 提交达到阈值 → 自动打 patch tag → 自动发布
+- `feat:` 提交达到阈值 → 开 `release-ready` issue → 人工确认 L4 绿了再打 tag
+- 不是盲目的 CD，是"patch 自动、feature 人工"的分级策略
+
+**drift 探测（`harness.yml`）：**
+- `govulncheck`: 依赖漏洞扫描
+- `deadcode`: 死代码检测
+- `go mod tidy -diff`: 依赖一致性
+- `required-checks alignment`: 分支保护规则与 CI job 名称对齐
+
+这些是 `continue-on-error: true` 的信息性检查，不会阻塞 PR，但会暴露 drift。这比"等到出事了再发现"好得多。
+
+### 3.3 优点：依赖选择克制且正确
+
+9 个直接依赖：
+- **Cobra** (CLI 框架) — 行业标准，没什么好说的
+- **Charmbracelet** (bubbletea + lipgloss + huh + bubbles) — 现代 TUI 生态里最好的选择
+- **testify** — Go 测试的事实标准
+- **yaml.v3** — YAML 解析的唯一合理选择
+- **fuzzy** — 一个轻量 fuzzy search，用于 package selector
+- **x/term** — 终端状态检测
+
+**没有多余的依赖。** 没有 `go-kit`，没有 `wire`，没有 `fx`，没有那些"我需要一个 DI 框架"的过度工程。一个 CLI 工具就该这样：用最少的依赖完成工作。
+
+### 3.4 优点：golangci-lint 配置到位
+
+12 个 linter 启用（包括 `errcheck`, `staticcheck`, `gosec`, `gocyclo`, `exhaustive`），复杂度阈值设为 20（对安装器类代码合理）。`goimports` 配了本地包前缀。测试文件排除了 `errcheck` 和 `gosec`（正确，测试里不需要这些噪音）。
+
+### 3.5 优点：Git hooks 设计合理
+
+- **pre-commit** (<5s): `go vet` + `go build` + `golangci-lint --new-from-rev=HEAD~1`（只检查 diff）
+- **pre-push** (~75s): 完整 L1 测试带 `-race`
+
+这个分层是对的：提交时做快速检查（别让明显的错误进去），推送时做完整测试（别让不工作的代码到远端）。
+
+### 3.6 问题：Claude 钩子是认真的
+
+`.claude/hooks/` 里有：
+- `post-tool-use.sh`: 每次 Edit/Write 后自动跑 `go vet`
+- `stop.sh`: 每轮对话结束时，如果 `.go` 文件有变更就跑 `go vet ./...` + archtest
+
+这意味着这个项目不只是用 AI 辅助开发，而是**给 AI 加了护栏**。AI 改了代码？立刻用 go vet 验证。AI 完成一轮对话？跑 archtest 确认没违反架构约束。
+
+这是 Martin Fowler 说的 "Harness Engineering" 的实践。**大多数项目连给人类加 linter 都做不好，这个项目在给 AI 加 fitness function。** 认真的。
+
+---
+
+## 四、性能与潜在风险
+
+### 4.1 优点：并发是保守的，这是对的
+
+整个代码库只有 **7 个 `go func`**，全部有明确的生命周期管理：
+- `sync.WaitGroup` 等待完成
+- channel 信号关闭
+- `closeOnce` 防止 double-close panic
+
+**没有无界 goroutine。** brew 安装是顺序的（有重试），只有 `GetInstalledPackages` 用了 2 个 goroutine 并行获取 formula + cask 列表。
+
+对于一个安装器工具来说，"保守的并发"是正确的选择。你不需要一个 goroutine pool 来并行安装 20 个 brew 包——brew 本身就有锁，并行安装只会更慢。
+
+### 4.2 优点：资源清理到位
+
+- **120+ 处 `defer`** 用于清理
+- **所有 HTTP response body 都有 `defer resp.Body.Close()`**
+- **io.LimitReader 到处都是：** HTTP 响应限制 1MB，snapshot 导入限制 10MB，错误响应限制 64KB
+- **临时文件显式清理：** `defer os.Remove(tmpFile.Name())`
+
+没有资源泄漏。这不是"我觉得没有"，是"我检查了所有 HTTP 调用和文件操作，每个都有对应的清理"。
+
+### 4.3 优点：原子写入保护状态文件
+
+```go
+// 写入流程：
+// 1. 写入 .tmp 文件
+// 2. rename .tmp → 目标文件
+// 3. rename 失败则清理 .tmp
+```
+
+`state/reminder.go` 和 `installer/state.go` 都用了这个模式。这意味着即使进程在写入过程中被 kill，状态文件要么是旧的完整版本，要么是新的完整版本，永远不会是半截的损坏数据。
+
+### 4.4 优点：安全实践扎实
+
+- **Token 存储：** `0600` 权限，目录 `0700`
+- **无命令注入：** 所有子进程调用使用硬编码的二进制名 + 参数列表，不经过 shell
+- **shell 标识符验证：** 正则过滤 ZSH_THEME/plugins，防止注入
+- **无硬编码密钥：** 已确认
+
+### 4.5 问题：没有跨步骤回滚机制
+
+installer 的 7 步各自独立失败，失败收集到 `softErrs` 切片里。但如果 brew 装了一半、npm 全装了、然后 shell 配置挂了——没有办法"回到安装前的状态"。
+
+现在的缓解措施是**每包保存状态**（`state.markFormula`, `state.markCask`），允许从上次中断的地方恢复。这在实践中够用了——大多数用户不需要"回滚"，他们需要"重试"。
+
+但如果你将来要做 `openboot uninstall --everything`，你就需要一个真正的事务模型了。现在不需要，但要知道这个限制存在。
+
+### 4.6 问题：snapshot capture 里的类型断言可能静默失败
+
+```go
+formulae, _ := results[0].([]string)
+```
+
+这个 `_` 吞掉了断言失败。如果 `results[0]` 不是 `[]string`，`formulae` 会是 `nil`，然后程序继续跑，用一个空的 formulae 列表。**没有 panic，没有日志，没有任何迹象告诉你出了问题。**
+
+这在生产代码里是不能接受的。要么用 `v, ok := results[0].([]string); if !ok { ... }`，要么（更好的方案）别用 `interface{}` + 类型断言这种模式。
+
+### 4.7 轻微问题：Screenshots 目录权限过于宽松
+
+`internal/macos/macos.go` 中 Screenshots 目录用了 `0750`（组可读），而其他所有敏感目录都用 `0700`。不是安全漏洞，但是不一致。
+
+---
+
+## 五、致命问题
+
+**没有致命问题。**
+
+说真的，我翻遍了代码库，找不到一个"这会在生产中炸掉"或"这是根本性的架构错误"级别的问题。这在 code review 里不常见。
+
+上面列出的问题——`interface{}` 滥用、dry-run 重复、少量裸 `return err`——都是"让它更好"的建议，不是"不修这个会死"的警告。
+
+---
+
+## 六、一般问题（可接受但不优雅）
+
+1. **`interface{}` 在 snapshot capture 中** — 应该用类型化结构体替代（前面已详述）
+2. **43 处 dry-run 守卫重复** — 提取 helper 函数
+3. **49 处裸 `return err`** — 在 82% 包装率的代码库里显得不一致
+4. **ui/ 包 3,578 LOC** — 考虑拆分 helpers 和 bubbletea models
+5. **fmtprint 基线有 161 处违规** — 说明从 `fmt.Println` 到 `ui.*` 的迁移还没完成
+6. **测试 seam 模式不统一** — 有的用 Runner 接口，有的用模块级 `var` 覆盖（如 `sleepFunc`, `brewCaskInstallFunc`）
+7. **Screenshots 目录 `0750`** — 应改为 `0700` 保持一致
+
+---
+
+## 七、是否值得学习？
+
+**是。明确的是。**
+
+值得学习的点（按优先级）：
+
+1. **Archtest fitness function 模式** — 用 AST 分析在测试阶段强制架构约束，比文档 + code review 可靠一个数量级。如果你只从这个项目学一样东西，学这个。
+
+2. **四层测试策略（L1–L4）** — 从快速的 faked-runner 单元测试到真实 macOS VM 上的破坏性 e2e，覆盖了从"代码逻辑对不对"到"真机上能不能跑"的完整光谱。
+
+3. **Harness Engineering 实践** — `docs/HARNESS.md` 不只是文档，是一个"当问题反复出现时，改哪个文件来防止它再次出现"的决策框架。这是从 Martin Fowler 的方法论到工程实践的落地。
+
+4. **AI 护栏设计** — 给 Claude Code 加 post-tool-use hook 和 stop hook，让 AI 的每次代码修改都经过自动验证。这比"相信 AI 不会犯错"现实得多。
+
+5. **Plan/Apply 分离** — 交互和副作用分开，让安装器既可测试又可扩展。
+
+6. **自动发布的分级策略** — patch 自动、feature 人工，不是"全自动 CD"的天真，也不是"手动发布"的低效。
+
+7. **Runner 接口** — 恰到好处的子进程抽象。四个方法，不多不少。
+
+---
+
+## 八、是否适合用于生产？
+
+**适合，在以下场景中：**
+
+| 场景 | 适合度 | 原因 |
+|------|:------:|------|
+| 个人/团队开发环境配置 | ✅✅✅ | 这就是它的核心用途，覆盖完整 |
+| 公司内部开发者 onboarding | ✅✅ | 需要自定义 preset + 可能需要额外的网络/代理配置 |
+| CI/CD 环境初始化 | ✅ | 静默模式可用，但不是主要设计目标 |
+| 非 macOS 平台 | ❌ | 明确声明 macOS-only，不是缺陷而是设计决策 |
+
+**生产就绪度的具体证据：**
+- 原子状态写入 → 不怕断电/kill
+- 每包状态追踪 → 可从中断处恢复
+- 错误收集而非 panic → 部分失败不影响其余步骤
+- HTTP 超时 + 重试 + 限流 → 网络问题不会卡死
+- L4 在真实 macOS VM 上验证 → 不只是"理论上能跑"
+
+**不适合的场景：**
+- 需要跨步骤原子回滚的关键基础设施配置
+- 需要在 Linux/Windows 上运行的跨平台场景
+- 需要管理数百台机器的 fleet 配置（这是 Ansible/Chef/Puppet 的活）
+
+---
+
+## 九、总结
+
+这个项目给我的感觉是：**一个真正理解工程纪律的人（或团队）做的东西。**
+
+不是那种"用 Go 写个 CLI 发到 GitHub"的周末项目。从四层测试策略、archtest fitness function、harness engineering 文档、自动发布管线、到给 AI 加护栏——每一层都说明作者在认真思考"如何让这个项目长期可维护"。
+
+在"开发者环境配置 CLI"这个赛道里（包括 Nix、Homebrew Bundle、yadm、chezmoi 等），OpenBoot 在代码质量和工程实践上处于**高水平**。它的功能范围比不上 Nix 的声明式管理，但在它选择的范围内，做得很扎实。
+
+**最后一句话：** 如果每个 Go CLI 项目都有这种程度的测试覆盖和架构守护，我们这个行业会少很多半夜被叫起来修 bug 的事情。
+
+---
+
+*评审完成时间：2026-05-26*
+*评审依据：完整代码库静态分析 + 架构审查 + CI/CD 管线审查 + 安全审查*

--- a/internal/archtest/baseline/no-direct-exec.txt
+++ b/internal/archtest/baseline/no-direct-exec.txt
@@ -3,7 +3,7 @@
 # Regenerate: ARCHTEST_UPDATE_BASELINE=1 go test ./internal/archtest/...
 internal/auth/login.go:195
 internal/brew/brew_install.go:327
-internal/cli/snapshot.go:21
+internal/cli/snapshot.go:22
 internal/diff/compare.go:247
 internal/diff/compare.go:253
 internal/dotfiles/dotfiles.go:23

--- a/internal/archtest/baseline/no-raw-http.txt
+++ b/internal/archtest/baseline/no-raw-http.txt
@@ -3,7 +3,7 @@
 # Regenerate: ARCHTEST_UPDATE_BASELINE=1 go test ./internal/archtest/...
 internal/auth/login.go:106
 internal/auth/login.go:164
-internal/cli/snapshot_import.go:70
+internal/cli/snapshot_import.go:71
 internal/cli/snapshot_publish.go:142
 internal/config/packages_remote.go:82
 internal/config/packages_remote.go:87

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -16,6 +16,7 @@ import (
 	syncpkg "github.com/openbootdotdev/openboot/internal/sync"
 	"github.com/openbootdotdev/openboot/internal/system"
 	"github.com/openbootdotdev/openboot/internal/ui"
+	"github.com/openbootdotdev/openboot/internal/ui/tui"
 )
 
 // installCfg is the config instance used by the install subcommand.
@@ -345,7 +346,7 @@ func runSyncInstall(source *syncpkg.SyncSource, pickRaw string) error { //nolint
 			// No filtering — the unmodified diff is used below.
 		case customizeChoiceCustomize:
 			additionsRC := remoteConfigFromSyncDiffAdditions(rc, diff)
-			picks, confirmed, err := ui.RunConfigCustomizer(additionsRC)
+			picks, confirmed, err := tui.RunConfigCustomizer(additionsRC)
 			if err != nil {
 				return fmt.Errorf("customizer: %w", err)
 			}
@@ -495,7 +496,7 @@ func promptCustomizeAndApply(rc *config.RemoteConfig) (*config.RemoteConfig, boo
 	case customizeChoiceAll:
 		return rc, true, nil
 	case customizeChoiceCustomize:
-		picks, confirmed, err := ui.RunConfigCustomizer(rc)
+		picks, confirmed, err := tui.RunConfigCustomizer(rc)
 		if err != nil {
 			return nil, false, fmt.Errorf("customizer: %w", err)
 		}

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openbootdotdev/openboot/internal/snapshot"
 	"github.com/openbootdotdev/openboot/internal/ui"
+	"github.com/openbootdotdev/openboot/internal/ui/tui"
 )
 
 var openBrowser = func(url string) error {
@@ -296,7 +297,7 @@ func captureWithUI() (*snapshot.Snapshot, error) {
 }
 
 func reviewSnapshot(snap *snapshot.Snapshot) (*snapshot.Snapshot, bool, error) {
-	edited, confirmed, err := ui.RunSnapshotEditor(snap)
+	edited, confirmed, err := tui.RunSnapshotEditor(snap)
 	if err != nil {
 		return nil, false, fmt.Errorf("snapshot editor: %w", err)
 	}

--- a/internal/cli/snapshot_import.go
+++ b/internal/cli/snapshot_import.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openbootdotdev/openboot/internal/installer"
 	"github.com/openbootdotdev/openboot/internal/snapshot"
 	"github.com/openbootdotdev/openboot/internal/ui"
+	"github.com/openbootdotdev/openboot/internal/ui/tui"
 )
 
 func runSnapshotImport(importPath string, dryRun bool) error {
@@ -41,7 +42,7 @@ func runSnapshotImport(importPath string, dryRun bool) error {
 
 	showRestoreInfo(snap, importPath)
 
-	edited, confirmed, err := ui.RunSnapshotEditor(snap)
+	edited, confirmed, err := tui.RunSnapshotEditor(snap)
 	if err != nil {
 		return fmt.Errorf("snapshot editor: %w", err)
 	}

--- a/internal/installer/plan.go
+++ b/internal/installer/plan.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openbootdotdev/openboot/internal/shell"
 	"github.com/openbootdotdev/openboot/internal/system"
 	"github.com/openbootdotdev/openboot/internal/ui"
+	"github.com/openbootdotdev/openboot/internal/ui/tui"
 )
 
 // InstallPlan captures all resolved decisions from the interactive planning phase.
@@ -199,7 +200,7 @@ func planPackages(opts *config.InstallOptions, st *config.InstallState, plan *In
 	if opts.Silent || (opts.DryRun && !system.HasTTY()) {
 		st.SelectedPkgs = config.GetPackagesForPreset(opts.Preset)
 	} else {
-		selected, onlinePkgs, confirmed, err := ui.RunSelector(opts.Preset)
+		selected, onlinePkgs, confirmed, err := tui.RunSelector(opts.Preset)
 		if err != nil {
 			return fmt.Errorf("run package selector: %w", err)
 		}
@@ -279,7 +280,7 @@ func planMacOSDecision(opts *config.InstallOptions) ([]macos.Preference, error) 
 	if opts.Macos == "configure" || opts.Silent || (opts.DryRun && !system.HasTTY()) {
 		return macos.DefaultPreferences, nil
 	}
-	selected, confirmed, err := ui.RunMacOSSelector()
+	selected, confirmed, err := tui.RunMacOSSelector()
 	if err != nil {
 		return nil, fmt.Errorf("macOS selector: %w", err)
 	}

--- a/internal/ui/AGENTS.md
+++ b/internal/ui/AGENTS.md
@@ -1,34 +1,33 @@
 # UI PACKAGE
 
-TUI components built on Charmbracelet (bubbletea + lipgloss + huh). 5 files, 2,206 lines.
+Output helpers, progress widgets, and form wrappers. Bubbletea TUI models
+live in the `tui/` subpackage.
 
-## FILES
+## FILES (internal/ui/)
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| `selector.go` | 986 | Package selector: tabs, fuzzy search, online search, multi-select |
-| `snapshot_editor.go` | 518 | Snapshot editing: diff view, toggle packages, confirm |
-| `progress.go` | 289 | StickyProgress: per-package timing, succeeded/failed/skipped counters |
-| `scanprogress.go` | 228 | Scan progress: step timing, overall counter `[3/8]` |
-| `ui.go` | 185 | Base styles, form helpers (SelectPreset, InputGitConfig, Confirm) |
+| `ui.go` | 247 | Base styles, color helpers, output helpers (Header/Success/Error/Info/Warn/Muted/DryRun*), huh form wrappers (InputGitConfig, SelectPreset, Confirm, SelectOption, Input) |
+| `progress.go` | 246 | StickyProgress: per-package timing, succeeded/failed/skipped counters |
+| `scanprogress.go` | 221 | ScanProgress: step timing, overall counter `[3/8]` |
+| `scrollregion.go` | 143 | ANSI scroll-region plumbing for StickyProgress |
+
+## FILES (internal/ui/tui/)
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `selector.go` + `selector_view.go` | ~1,026 | Package selector: tabs, fuzzy search, online search, multi-select |
+| `snapshot_editor.go` + `snapshot_editor_search.go` | ~1,022 | Snapshot editing: diff view, toggle packages, add online, confirm |
+| `config_customizer.go` | 253 | Remote-config customizer: toggle which packages to install |
+| `macos_selector.go` | 435 | macOS preferences selector: category tabs, toggle, confirm |
 
 ## PATTERNS
 
-- **bubbletea Model**: `selector.go` and `snapshot_editor.go` implement `tea.Model` (Init/Update/View)
+- **bubbletea Model**: `tui/*.go` files implement `tea.Model` (Init/Update/View)
 - **Sticky output**: `progress.go` writes directly to stderr via ANSI escape codes, not bubbletea
 - **Styles**: All lipgloss styles defined as package-level vars at top of file
 - **Color palette**: Primary=#22c55e, Subtle=#666, Warning=#eab308, Danger=#ef4444
 - **Width adaptation**: Components read `tea.WindowSizeMsg` and adapt layout
-
-## SELECTOR ARCHITECTURE (selector.go)
-
-Two render modes: normal (tab navigation) and search (`/` key).
-
-- **Tab bar**: Sliding window — shows active tab + neighbors + `N/M` position. Adapts to terminal width.
-- **Search**: Fuzzy local match (sahilm/fuzzy) + debounced online search (500ms). Animated spinner during fetch.
-- **Toast**: 1.5s auto-fade notifications on toggle (`+ Added node` / `- Removed node`).
-- **Scroll**: `scrollOffset` + `getVisibleItems()` for height-adaptive list (5-20 items).
-- **Alt screen**: Uses `tea.WithAltScreen()` for full-screen mode.
 
 ## PROGRESS ARCHITECTURE (progress.go)
 
@@ -41,7 +40,7 @@ NOT a bubbletea model. Direct stderr writer for use during brew install.
 
 ## WHEN ADDING NEW UI
 
-1. Interactive full-screen → bubbletea Model in new file
-2. Progress/status during install → extend StickyProgress or ScanProgress
-3. Simple form input → use helpers in ui.go (huh-based)
-4. Styled text output → use ui.Header/Success/Error/Info/Warn/Muted
+1. Interactive full-screen → bubbletea Model in `tui/` subpackage
+2. Progress/status during install → extend StickyProgress or ScanProgress in `ui/`
+3. Simple form input → use helpers in `ui.go` (huh-based)
+4. Styled text output → use `ui.Header`/`Success`/`Error`/`Info`/`Warn`/`Muted`

--- a/internal/ui/tui/config_customizer.go
+++ b/internal/ui/tui/config_customizer.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"fmt"

--- a/internal/ui/tui/config_customizer_test.go
+++ b/internal/ui/tui/config_customizer_test.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"testing"

--- a/internal/ui/tui/macos_selector.go
+++ b/internal/ui/tui/macos_selector.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"fmt"

--- a/internal/ui/tui/macos_selector_test.go
+++ b/internal/ui/tui/macos_selector_test.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"strings"

--- a/internal/ui/tui/selector.go
+++ b/internal/ui/tui/selector.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"fmt"

--- a/internal/ui/tui/selector_test.go
+++ b/internal/ui/tui/selector_test.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"strings"

--- a/internal/ui/tui/selector_view.go
+++ b/internal/ui/tui/selector_view.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"fmt"
@@ -66,6 +66,12 @@ var (
 	searchBarHintStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#555")).
 				Italic(true)
+
+	// scanActiveStyle is duplicated from the parent ui package (where it
+	// lives in scanprogress.go) to avoid a circular import.  The canonical
+	// colour definition is lipgloss.Color("#06b6d4").
+	scanActiveStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#06b6d4"))
 )
 
 func (m SelectorModel) getVisibleItems() int {

--- a/internal/ui/tui/snapshot_editor.go
+++ b/internal/ui/tui/snapshot_editor.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"fmt"

--- a/internal/ui/tui/snapshot_editor_search.go
+++ b/internal/ui/tui/snapshot_editor_search.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"fmt"

--- a/internal/ui/tui/snapshot_editor_test.go
+++ b/internal/ui/tui/snapshot_editor_test.go
@@ -1,4 +1,4 @@
-package ui
+package tui
 
 import (
 	"fmt"


### PR DESCRIPTION
## Summary
- Split `internal/ui/` (5,715 LOC) into two packages:
  - `internal/ui/` (1,180 LOC) — output helpers, huh forms, StickyProgress, ScanProgress
  - `internal/ui/tui/` (4,541 LOC) — all bubbletea Model types (selector, snapshot editor, config customizer, macOS selector)
- Updated 4 callers: `installer/plan.go`, `cli/install.go`, `cli/snapshot.go`, `cli/snapshot_import.go`
- Duplicated one lipgloss style in `tui/` to avoid circular import back to `ui/`

## Test plan
- [x] `go test ./internal/ui/...` passes
- [x] `go test ./internal/ui/tui/...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/archtest/...` passes (baselines updated for line shifts)