### PR TITLE
docs: sync archtest enforcement status in AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ update the baseline — do not silence the rule.
 | `http.NewRequest` / `http.DefaultClient` only in `internal/httputil` | `internal/archtest/http_test.go` |
 | Use `os.UserHomeDir()` — never `os.Getenv("HOME")` | `internal/archtest/envhome_test.go` |
 | Error wrapping with `%w`, no bare returns | reviewer + `errcheck` (golangci-lint) |
-| UI output via `ui.*` helpers — never raw `fmt.Println` in user-facing paths | reviewer (planned: archtest rule) |
+| UI output via `ui.*` helpers — never raw `fmt.Println` in user-facing paths | `internal/archtest/fmtprint_test.go` |
 | Destructive ops check `cfg.DryRun` before acting | `internal/archtest/dryrun_test.go` |
 
 The full convention list lives in CLAUDE.md → "Project-specific conventions".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ These cannot be inferred from code alone — everything else is enforced by `go 
 Bolded rules are enforced mechanically by `internal/archtest` (fitness functions in L1).
 
 - **Error wrapping**: `fmt.Errorf("context: %w", err)` — never bare returns.
-- **UI output**: always through `ui.*` helpers; raw `fmt.Println` is a bug in user-facing paths.
+- **UI output** *(archtest: `fmtprint`)*: always through `ui.*` helpers; raw `fmt.Println` is a bug in user-facing paths.
 - **Subprocess** *(archtest: `no-direct-exec`)*: `system.RunCommand` (interactive) / `system.RunCommandSilent` (captured). Do not call `exec.Command` directly from feature code — add to `system/` if a wrapper is missing.
 - **Destructive ops** *(archtest: `dryrun`)*: check `cfg.DryRun` first. Always.
 - **Paths** *(archtest: `no-os-getenv-home`)*: `os.UserHomeDir()` — never hardcode `~` or `/Users/...`, never `os.Getenv("HOME")`.


### PR DESCRIPTION
## Summary
- AGENTS.md: fmtprint invariant updated from `reviewer (planned: archtest rule)` → `internal/archtest/fmtprint_test.go`
- CLAUDE.md: UI output convention tagged with `(archtest: fmtprint)` to match other enforced rules

All 5 archtest rules now consistently documented as mechanically enforced.

## Test plan
- [x] No code changes — docs only