### PR TITLE
ci,fix: stop drift-to-issue skipped emails; replace log.Fatalf with panic in config init

### DIFF
--- a/.github/workflows/drift-to-issue.yml
+++ b/.github/workflows/drift-to-issue.yml
@@ -21,12 +21,12 @@ permissions:
 
 jobs:
   open-or-update-issue:
-    if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Find failed jobs and (re)open issues
+        if: github.event.workflow_run.conclusion == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}

--- a/internal/config/packages.go
+++ b/internal/config/packages.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"embed"
-	"log"
 	"sync"
 
 	"gopkg.in/yaml.v3"
@@ -36,12 +35,12 @@ var (
 func init() {
 	data, err := packagesYAML.ReadFile("data/packages.yaml")
 	if err != nil {
-		log.Fatalf("Failed to read packages.yaml: %v", err)
+		panic("corrupt binary: embedded packages.yaml unreadable: " + err.Error())
 	}
 
 	var pd packagesData
 	if err := yaml.Unmarshal(data, &pd); err != nil {
-		log.Fatalf("Failed to parse packages.yaml: %v", err)
+		panic("corrupt binary: embedded packages.yaml unparseable: " + err.Error())
 	}
 
 	Categories = pd.Categories

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"embed"
-	"log"
 
 	"gopkg.in/yaml.v3"
 )
@@ -16,12 +15,12 @@ var presetOrder = []string{"minimal", "developer", "full"}
 func init() {
 	data, err := presetsYAML.ReadFile("data/presets.yaml")
 	if err != nil {
-		log.Fatalf("Failed to read presets.yaml: %v", err)
+		panic("corrupt binary: embedded presets.yaml unreadable: " + err.Error())
 	}
 
 	var pd presetsData
 	if err := yaml.Unmarshal(data, &pd); err != nil {
-		log.Fatalf("Failed to parse presets.yaml: %v", err)
+		panic("corrupt binary: embedded presets.yaml unparseable: " + err.Error())
 	}
 
 	Presets = pd.Presets


### PR DESCRIPTION
## Summary

- Move `if: conclusion == 'failure'` from the job level to the step level in `drift-to-issue.yml` so the workflow reports `success` (not `skipped`) when no failure is detected — GitHub only sends emails on `failure`, so the skipped-job emails stop
- Replace `log.Fatalf` with `panic` in `internal/config/packages.go` and `internal/config/presets.go` `init()` functions: `log.Fatal` calls `os.Exit(1)` which skips all deferred cleanup; `panic` is the correct primitive for a startup assertion on compiled-in static data that should never fail

## Test plan

- [x] `unit (L1)` passes on CI
- [x] `lint` passes on CI
- [x] `go build ./...` + `go vet ./...` clean locally
- [x] drift sensors (deadcode, govulncheck, go mod tidy) all pass