### PR TITLE
fix: clone all external zsh plugins on remote-config installs

### DIFF
--- a/internal/config/data/zsh-plugins.yaml
+++ b/internal/config/data/zsh-plugins.yaml
@@ -13,3 +13,7 @@ plugins:
     repo: https://github.com/zsh-users/zsh-completions
   - name: zsh-history-substring-search
     repo: https://github.com/zsh-users/zsh-history-substring-search
+  - name: fast-syntax-highlighting
+    repo: https://github.com/zdharma-continuum/fast-syntax-highlighting
+  - name: zsh-autocomplete
+    repo: https://github.com/marlonrichert/zsh-autocomplete

--- a/internal/config/zshplugins_test.go
+++ b/internal/config/zshplugins_test.go
@@ -13,6 +13,22 @@ func TestZshPluginRepoURL_KnownExternal(t *testing.T) {
 	assert.True(t, strings.HasPrefix(url, "https://"), "repo URL must be https, got %q", url)
 }
 
+func TestZshPluginRepoURL_PopularExternalPlugins(t *testing.T) {
+	// Regression: these external plugins were referenced by real user configs
+	// but missing from the catalog, so cloneExternalPlugins skipped them and
+	// oh-my-zsh logged "plugin not found" at shell startup.
+	for _, name := range []string{
+		"zsh-autosuggestions",
+		"zsh-syntax-highlighting",
+		"fast-syntax-highlighting",
+		"zsh-autocomplete",
+	} {
+		url, ok := ZshPluginRepoURL(name)
+		assert.True(t, ok, "%s should be a known external plugin", name)
+		assert.True(t, strings.HasPrefix(url, "https://"), "%s repo must be https, got %q", name, url)
+	}
+}
+
 func TestZshPluginRepoURL_BuiltinReturnsFalse(t *testing.T) {
 	for _, builtin := range []string{"git", "docker", "kubectl", "z"} {
 		url, ok := ZshPluginRepoURL(builtin)

--- a/internal/installer/plan.go
+++ b/internal/installer/plan.go
@@ -93,6 +93,12 @@ func planFromRemoteConfig(opts *config.InstallOptions, st *config.InstallState, 
 
 	if rc.Shell != nil && rc.Shell.OhMyZsh {
 		plan.InstallOhMyZsh = true
+		// Carry theme and plugins through so applyShell takes the restore path
+		// (writes plugins=() and git-clones external plugins). Dropping these
+		// silently downgraded remote-config installs to a bare OMZ install with
+		// no plugins cloned.
+		plan.ShellTheme = rc.Shell.Theme
+		plan.ShellPlugins = rc.Shell.Plugins
 	}
 
 	for _, p := range rc.MacOSPrefs {

--- a/internal/installer/plan_test.go
+++ b/internal/installer/plan_test.go
@@ -418,6 +418,29 @@ func TestPlanFromSnapshot_ShellRestored(t *testing.T) {
 	assert.Equal(t, []string{"git", "kubectl"}, plan.ShellPlugins)
 }
 
+func TestPlan_RemoteConfig_ShellThemeAndPluginsRestored(t *testing.T) {
+	// Regression: planFromRemoteConfig used to set only InstallOhMyZsh and drop
+	// the theme/plugins, so `openboot install <slug>` installed a bare OMZ and
+	// never wrote plugins=() or cloned external plugins.
+	opts := &config.InstallOptions{DryRun: true, Silent: true}
+	st := &config.InstallState{
+		RemoteConfig: &config.RemoteConfig{
+			Shell: &config.RemoteShellConfig{
+				OhMyZsh: true,
+				Theme:   "robbyrussell",
+				Plugins: []string{"git", "zsh-autosuggestions", "fast-syntax-highlighting"},
+			},
+		},
+	}
+
+	plan, err := Plan(opts, st)
+	require.NoError(t, err)
+
+	assert.True(t, plan.InstallOhMyZsh)
+	assert.Equal(t, "robbyrussell", plan.ShellTheme)
+	assert.Equal(t, []string{"git", "zsh-autosuggestions", "fast-syntax-highlighting"}, plan.ShellPlugins)
+}
+
 func TestPlanFromSnapshot_ShellSkipFlag(t *testing.T) {
 	cfg := &config.Config{
 		InstallOptions: config.InstallOptions{


### PR DESCRIPTION
## Summary

Fixes two bugs that left oh-my-zsh logging `plugin '...' not found` at every
shell startup for configs that list external plugins.

- **Catalog was incomplete.** `data/zsh-plugins.yaml` was missing
  `fast-syntax-highlighting` and `zsh-autocomplete`. `cloneExternalPlugins`
  treats catalog misses as built-in/unknown and skips the git clone, so these
  two were never cloned. Added both with their canonical maintained repos
  (`zdharma-continuum/fast-syntax-highlighting`, `marlonrichert/zsh-autocomplete`).

- **Remote-config installs dropped theme/plugins.** `planFromRemoteConfig`
  set `plan.InstallOhMyZsh` from `rc.Shell.OhMyZsh` but ignored
  `rc.Shell.Theme` and `rc.Shell.Plugins`. As a result `openboot install <slug>`
  took the bare "fresh install" branch in `applyShell` — installing Oh-My-Zsh
  but never writing `plugins=()` nor cloning any external plugins, even the ones
  already in the catalog. The snapshot/state path (`PlanFromSnapshot`) already
  copied all three fields; this brings the remote-config path in line.

Together these mean installing a config that lists external plugins now clones
them into `$ZSH_CUSTOM/plugins` instead of leaving zsh to warn on every login.

## Test plan

- [x] `go vet ./internal/...`
- [x] `go test ./internal/installer/... ./internal/config/... ./internal/archtest/...`
- [x] New regression test: catalog contains the popular external plugins
      (`TestZshPluginRepoURL_PopularExternalPlugins`)
- [x] New regression test: remote-config plan carries theme + plugins
      (`TestPlan_RemoteConfig_ShellThemeAndPluginsRestored`)

https://claude.ai/code/session_019iBMJXrKC2FXQ4hWay8Lds

---
_Generated by [Claude Code](https://claude.ai/code/session_019iBMJXrKC2FXQ4hWay8Lds)_