### PR TITLE
chore: add cross-repo checklist to PR template and teach ship-pr to use it

### DIFF
--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -51,6 +51,20 @@ is not installed, that's the user's choice; CI will still gate.
 
 ### Step 3 — Open the PR
 
+Before writing the body, check for a PR template:
+
+```bash
+cat .github/pull_request_template.md 2>/dev/null
+```
+
+If the file exists, use it as the body structure — fill in its sections
+rather than inventing a different format. Do **not** discard the template
+by passing a completely custom `--body` that ignores it. If the template
+has a cross-repo checklist item (e.g. "does this need a docs update in
+openboot.dev?"), answer it honestly.
+
+If no template exists, fall back to the default structure:
+
 ```bash
 gh pr create --title "<conventional commit subject>" --body "$(cat <<'EOF'
 ## Summary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,11 @@
 - [ ] Relevant tests added or updated
 - [ ] Tested locally (`./openboot install --dry-run` or similar)
 
+## Cross-repo checklist
+
+- [ ] Does this need a docs/content update in `openboot.dev`?
+- [ ] Does this change the CLI ↔ server API contract? (update `openboot-contract` first)
+
 ## Notes for reviewer
 
 <!-- Anything that needs extra context or attention? -->


### PR DESCRIPTION
## What does this PR do?

Adds a cross-repo checklist section to the PR template and updates the `ship-pr` skill to read the template before opening a PR instead of using a hardcoded body.

## Why?

When a change spans multiple repos (e.g. CLI feature + docs update in openboot.dev), it's easy to forget the other repo. A checklist in the PR template surfaces the question at the right moment — for both humans and agents.

The `ship-pr` skill was previously writing its own `--body` unconditionally, which would silently discard the template. It now reads `.github/pull_request_template.md` first and fills in its sections.

## Testing

- [x] `go vet ./...` passes
- [ ] Relevant tests added or updated
- [x] Tested locally (`./openboot install --dry-run` or similar)

## Cross-repo checklist

- [ ] Does this need a docs/content update in `openboot.dev`?
- [ ] Does this change the CLI ↔ server API contract? (update `openboot-contract` first)

## Notes for reviewer

Skill files under `.claude/skills/` are not Go code — no unit tests apply. The change is verified by reading the before/after of the two modified files.