### PR TITLE
fix: back up stow conflicts before make install

### DIFF
--- a/internal/archtest/baseline/no-direct-exec.txt
+++ b/internal/archtest/baseline/no-direct-exec.txt
@@ -9,8 +9,8 @@ internal/diff/compare.go:253
 internal/dotfiles/dotfiles.go:23
 internal/dotfiles/dotfiles.go:32
 internal/dotfiles/dotfiles.go:66
-internal/dotfiles/dotfiles.go:318
-internal/dotfiles/dotfiles.go:416
+internal/dotfiles/dotfiles.go:351
+internal/dotfiles/dotfiles.go:449
 internal/installer/step_system.go:85
 internal/npm/npm.go:22
 internal/permissions/screen_recording_cgo.go:21

--- a/internal/dotfiles/dotfiles.go
+++ b/internal/dotfiles/dotfiles.go
@@ -254,8 +254,41 @@ func linkWithMake(dotfilesPath string, dryRun bool) error {
 		ui.DryRunMsg("Would run make install in %s", dotfilesPath)
 		return nil
 	}
+
+	home, err := system.HomeDir()
+	if err != nil {
+		return fmt.Errorf("make install home: %w", err)
+	}
+
+	// Back up files that would conflict with stow-style Makefiles before
+	// running make install — the Makefile commonly delegates to stow, which
+	// aborts on pre-existing regular files.
+	var allBacked [][2]string
+	if entries, rdErr := os.ReadDir(dotfilesPath); rdErr == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			pkgDir := filepath.Join(dotfilesPath, entry.Name())
+			backed, backupErr := backupConflicts(pkgDir, home, false)
+			if backupErr != nil {
+				return fmt.Errorf("backup conflicts for %s: %w", entry.Name(), backupErr)
+			}
+			allBacked = append(allBacked, backed...)
+		}
+	}
+
 	if err := system.RunCommandInDir(dotfilesPath, "make", "install"); err != nil {
+		for _, pair := range allBacked {
+			restoreFile(pair[0], pair[1], false)
+		}
 		return fmt.Errorf("make install: %w", err)
+	}
+
+	for _, pair := range allBacked {
+		if rmErr := os.Remove(pair[0]); rmErr != nil {
+			ui.Warn(fmt.Sprintf("could not remove backup %s: %v", pair[0], rmErr))
+		}
 	}
 	return nil
 }

--- a/internal/dotfiles/dotfiles_test.go
+++ b/internal/dotfiles/dotfiles_test.go
@@ -153,6 +153,60 @@ func TestLinkWithMake_DryRun(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestLinkWithMake_BacksUpConflictsBeforeRunning(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	dotfilesPath := filepath.Join(tmpHome, defaultDotfilesDir)
+	pkgDir := filepath.Join(dotfilesPath, "git")
+	require.NoError(t, os.MkdirAll(pkgDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, ".gitconfig"), []byte("new"), 0644))
+
+	// Pre-existing file that would conflict with stow.
+	originalContent := "# original gitconfig\n"
+	require.NoError(t, os.WriteFile(filepath.Join(tmpHome, ".gitconfig"), []byte(originalContent), 0644))
+
+	// Makefile just touches a sentinel file — no real stow needed.
+	require.NoError(t, os.WriteFile(filepath.Join(dotfilesPath, "Makefile"),
+		[]byte("install:\n\ttouch \"$(HOME)/.make_ran\"\n"), 0644))
+
+	err := linkWithMake(dotfilesPath, false)
+	require.NoError(t, err)
+
+	// Sentinel confirms make ran.
+	_, statErr := os.Stat(filepath.Join(tmpHome, ".make_ran"))
+	assert.NoError(t, statErr, "make install should have run")
+
+	// Backup should be cleaned up after success.
+	_, backupErr := os.Stat(filepath.Join(tmpHome, ".gitconfig.openboot.bak"))
+	assert.True(t, os.IsNotExist(backupErr), "backup should be removed after success")
+}
+
+func TestLinkWithMake_RestoresConflictsOnMakeFailure(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	dotfilesPath := filepath.Join(tmpHome, defaultDotfilesDir)
+	pkgDir := filepath.Join(dotfilesPath, "git")
+	require.NoError(t, os.MkdirAll(pkgDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, ".gitconfig"), []byte("new"), 0644))
+
+	originalContent := "# original gitconfig\n"
+	require.NoError(t, os.WriteFile(filepath.Join(tmpHome, ".gitconfig"), []byte(originalContent), 0644))
+
+	// Makefile that always fails.
+	require.NoError(t, os.WriteFile(filepath.Join(dotfilesPath, "Makefile"),
+		[]byte("install:\n\texit 1\n"), 0644))
+
+	err := linkWithMake(dotfilesPath, false)
+	assert.Error(t, err)
+
+	// Original file should be restored.
+	content, readErr := os.ReadFile(filepath.Join(tmpHome, ".gitconfig"))
+	require.NoError(t, readErr)
+	assert.Equal(t, originalContent, string(content), ".gitconfig should be restored after make failure")
+}
+
 func TestLink_UsesMakefileOverStow(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)


### PR DESCRIPTION
## What does this PR do?

Pre-backs-up existing regular files that would conflict with stow before running `make install`, mirroring the logic already in `linkWithStow`.

## Why?

The v0.61.0 release workflow failed at the vm-e2e stage:

```
stow -v --target="/Users/runner" git ssh zsh
WARNING! stowing git would cause conflicts:
  * cannot stow .dotfiles/git/.gitconfig over existing target .gitconfig since neither a link nor a directory
WARNING! stowing zsh would cause conflicts:
  * cannot stow .dotfiles/zsh/.zshrc over existing target .zshrc since neither a link nor a directory
All operations aborted.
make: *** [install] Error 1
✗ Dotfiles setup failed: link dotfiles: make install: exit status 2
```

PR #123 added `linkWithMake` to prefer a Makefile's `install` target over calling stow directly, but didn't carry over the `backupConflicts` step that `linkWithStow` has always run. The default dotfiles repo's `Makefile` delegates to `stow`, which aborts on pre-existing files it can't replace. On the vm-e2e runner, `.gitconfig` and `.zshrc` exist from earlier installer steps.

## Testing

- [ ] `go vet ./...` passes
- [ ] Relevant tests added or updated — two new unit tests: `TestLinkWithMake_BacksUpConflictsBeforeRunning` and `TestLinkWithMake_RestoresConflictsOnMakeFailure`
- [ ] Tested locally (`./openboot install --dry-run` or similar)

## Cross-repo checklist

- [ ] Does this need a docs/content update in `openboot.dev`? — No
- [ ] Does this change the CLI ↔ server API contract? — No

## Notes for reviewer

`linkWithMake` now:
1. Scans each non-hidden subdirectory (stow package) for regular-file conflicts
2. Backs them up to `.openboot.bak` before running `make install`
3. Restores them if make fails
4. Cleans up backups on success

This is the same pattern `linkWithStow` has used since the feature landed.