### PR TITLE
chore: bump Go toolchain to 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openbootdotdev/openboot
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
## What does this PR do?

Bumps `go 1.25.10` → `go 1.25.11` in `go.mod`.

## Why?

`govulncheck (drift)` has been failing on every CI run with two stdlib vulns:

- **GO-2026-5039** — arbitrary inputs included in errors without escaping in `net/textproto`, fixed in go1.25.11
- **GO-2026-5037** — inefficient candidate hostname parsing in `crypto/x509`, fixed in go1.25.11

All workflows derive their Go version from `go-version-file: go.mod`, so this one-line change fixes both.

## Testing

- [x] `go vet ./...` passes
- [x] `go test ./internal/...` passes (all L1 green)
- [ ] Tested locally (`./openboot install --dry-run` or similar) — not required, stdlib bump only

## Cross-repo checklist

- [ ] Does this need a docs/content update in `openboot.dev`? — No
- [ ] Does this change the CLI ↔ server API contract? — No

## Notes for reviewer

Single line change in `go.mod`. All CI jobs use `go-version-file: go.mod` so no workflow edits needed.