### PR TITLE
ci: fix L4 vm-e2e under Homebrew tap-trust + stale OMZ hash

### DIFF
--- a/.github/workflows/vm-e2e-spike.yml
+++ b/.github/workflows/vm-e2e-spike.yml
@@ -20,6 +20,17 @@ jobs:
       - name: Build binary
         run: make build
 
+      # GitHub's macos-14 image ships with third-party taps (aws/tap,
+      # azure/bicep, hashicorp/tap) pre-installed. Recent Homebrew refuses
+      # to load formulae/casks from untrusted taps, which breaks `brew`
+      # operations the L4 suite drives. Trust everything already tapped so
+      # the runner behaves like a normal dev machine.
+      - name: Trust pre-existing Homebrew taps
+        run: |
+          brew tap | while read -r t; do
+            [ -n "$t" ] && brew trust "$t" 2>/dev/null || true
+          done
+
       - name: Run L4 vm tests
         run: |
           go test -v -timeout 55m -tags="e2e,vm" \

--- a/internal/archtest/baseline/no-direct-exec.txt
+++ b/internal/archtest/baseline/no-direct-exec.txt
@@ -14,7 +14,7 @@ internal/dotfiles/dotfiles.go:449
 internal/installer/step_system.go:132
 internal/npm/npm.go:22
 internal/permissions/screen_recording_cgo.go:21
-internal/shell/shell.go:178
+internal/shell/shell.go:184
 internal/updater/updater.go:205
 internal/updater/updater.go:212
 internal/updater/updater.go:219

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -20,15 +20,21 @@ import (
 	"github.com/openbootdotdev/openboot/internal/ui"
 )
 
-// knownOMZInstallHash is the SHA256 of the Oh-My-Zsh install script pinned on
-// 2026-04-19 (ohmyzsh/ohmyzsh master, commit circa that date). Update this
-// constant whenever the installer script changes upstream.
-const knownOMZInstallHash = "21043aec5b791ce4835479dc33ba2f92155946aeafd54604a8c83522627cc803"
+// knownOMZInstallHash is the SHA256 of the Oh-My-Zsh install script that
+// omzInstallURL points at. Both are pinned to ohmyzsh/ohmyzsh commit
+// 96ea17080a7addd1cd8b6253422776bc237fc6b1 (2026-06-15). Pinning to an
+// immutable commit (rather than a moving branch like master) keeps the URL
+// and this hash consistent — otherwise any upstream edit to the script
+// invalidates the hash and breaks `openboot install --shell install`.
+// To bump: pick a newer commit, update the URL below, and set this to the
+// SHA256 of that commit's tools/install.sh.
+const knownOMZInstallHash = "4534045f4d983abd9716cd2f515bbe3c2b31ba5b8fd1fef147838778427477bb"
 
 const omzInstallTimeout = 10 * time.Minute
 
-// omzInstallURL is a var so tests can redirect it without a real server.
-var omzInstallURL = "https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh"
+// omzInstallURL is pinned to an immutable commit (see knownOMZInstallHash).
+// It is a var so tests can redirect it without a real server.
+var omzInstallURL = "https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/96ea17080a7addd1cd8b6253422776bc237fc6b1/tools/install.sh"
 
 // omzHTTPClient is a var so tests can inject a mock transport.
 var omzHTTPClient = &http.Client{Timeout: 30 * time.Second}

--- a/test/e2e/vm_edge_cases_test.go
+++ b/test/e2e/vm_edge_cases_test.go
@@ -36,8 +36,8 @@ func TestVM_Edge_ShellActuallyWorks(t *testing.T) {
 	bin := vmCopyDevBinary(t, vm)
 
 	// Install with shell setup
-	_, err := vmRunDevBinaryWithGit(t, vm, bin, "install --preset minimal --silent --shell install --dotfiles skip --macos skip")
-	require.NoError(t, err)
+	out, err := vmRunDevBinaryWithGit(t, vm, bin, "install --preset minimal --silent --shell install --dotfiles skip --macos skip")
+	require.NoError(t, err, "install failed, output:\n%s", out)
 
 	t.Run("zsh_login_shell_starts", func(t *testing.T) {
 		// Run a command through a login zsh — this sources .zshrc

--- a/test/e2e/vm_helpers_test.go
+++ b/test/e2e/vm_helpers_test.go
@@ -25,6 +25,8 @@ func vmInstallViaBrew(t *testing.T, vm *testutil.MacHost) string {
 	script := strings.Join([]string{
 		fmt.Sprintf("export PATH=%q", brewPath),
 		"brew tap openbootdotdev/tap 2>/dev/null || true",
+		// Recent Homebrew refuses to install from untrusted third-party taps.
+		"brew trust openbootdotdev/tap 2>/dev/null || true",
 		"brew install openboot",
 	}, " && ")
 


### PR DESCRIPTION
## What does this PR do?

Gets the L4 vm-e2e suite (`vm-e2e-spike.yml`) green again and fixes a real user-facing break it surfaced: `openboot install --shell install` aborting on a stale Oh-My-Zsh hash.

## Why?

L4 had two unrelated failures, neither caused by recent feature work (#129):

1. **Homebrew tap-trust enforcement.** Recent Homebrew refuses to load formulae/casks from untrusted third-party taps. This broke `TestVM_Interactive_InstallScript` (installs from `openbootdotdev/tap`) and the macos-14 runner ships `aws/tap`, `azure/bicep`, `hashicorp/tap` pre-tapped and untrusted. Fixed by trusting pre-existing taps in the workflow and `openbootdotdev/tap` in the install helper. *(CI/test-only.)*

2. **Stale pinned Oh-My-Zsh installer hash.** `InstallOhMyZsh` fetched the installer from the ohmyzsh `master` branch but verified it against a hash pinned 2026-04-19. Upstream rewrote `tools/install.sh` on 2026-06-15, so **every** `openboot install --shell install` now aborts with "hash mismatch: download may be compromised". Fixed by pinning the URL to an immutable commit (`96ea1708`) and refreshing the hash — pinning URL+hash to the same commit stops a future upstream edit from silently breaking the installer again. *(Real production fix.)*

The edge test also now logs the dev-binary output on failure (it previously discarded it, making the fast exit impossible to diagnose).

## Testing

- [x] `go vet ./...` passes
- [x] Relevant tests added or updated (shell unit tests green; edge test instrumented)
- [x] L4 vm-e2e dispatched on this branch — **all 11 TestVM_* pass** (run 27956783712), including the two previously red (`Edge_ShellActuallyWorks`, `FullSetupConfiguresEverything`)
- [x] New OMZ hash verified independently (own fetch of pinned commit → `4534045f…77bb`)

## Cross-repo checklist

- [ ] Does this need a docs/content update in `openboot.dev`? — No.
- [ ] Does this change the CLI ↔ server API contract? — No.

## Notes for reviewer

- Touches `.github/workflows/vm-e2e-spike.yml` but only adds a setup step to a **non-required** workflow — no branch-protection / required-check changes, so no GitHub UI action needed.
- Two logically separate commits: `ci:` (tap-trust, test-only) and `fix:` (OMZ pin, production).
- The OMZ `master`→commit pin is a behaviour change: users now get the installer from a fixed verified commit rather than latest master. This is intentional — it makes the supply-chain hash check coherent.