### PR TITLE
ci: fix harness drift — Claude review, L4 trigger, Go 1.25.12

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,10 +19,14 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    # write on pull-requests + issues is required for the action to POST its
+    # review back to the PR: inline review comments use the pull-requests API,
+    # the summary comment uses the issues API. With read-only the review runs
+    # but silently posts nothing ("No buffered inline comments").
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/vm-e2e-spike.yml
+++ b/.github/workflows/vm-e2e-spike.yml
@@ -3,6 +3,8 @@ name: vm-e2e-spike
 on:
   push:
     branches: ["test/vm-e2e-speed"]
+  pull_request:
+    branches: [main, master]
   workflow_dispatch:
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openbootdotdev/openboot
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
## What does this PR do?

Fixes three harness/CI drifts surfaced while shipping #134: the Claude review bot never posts, L4 doesn't actually run on PRs, and the Go toolchain carries a known stdlib CVE.

## Why?

Three independent, evidence-backed fixes (one commit each):

**1. `ci: grant Claude review workflow write` —** the `Claude Code Review` workflow completes *successfully* on every PR but posts nothing. Run logs show the job's `GITHUB_TOKEN` had `PullRequests: read`; the action generates a review then silently drops it (`No buffered inline comments`). Bumping `pull-requests`/`issues` to `write` lets inline + summary comments post. Auth (`claude_code_oauth_token`) and the `/code-review` plugin prompt are left untouched — the logs show both already work, so this is the minimal fix.

**2. `ci: run L4 vm-e2e on every PR to main` —** CLAUDE.md and docs/HARNESS.md describe L4 as running "on every PR", but `vm-e2e-spike.yml` only triggered on push to `test/vm-e2e-speed` + manual dispatch. Adds a `pull_request` trigger (matching `test.yml` / `harness.yml`) so reality matches the doc. Stays **non-blocking** — not in `.github/required-checks.txt`.

**3. `chore(deps): bump Go toolchain to 1.25.12` —** resolves **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`), which govulncheck's drift sensor flags as `Found in: crypto/tls@go1.25.11 / Fixed in: crypto/tls@go1.25.12`. All CI reads `go-version-file: go.mod`.

## Testing

- [x] `go vet ./...` passes / `make build` OK after the Go bump
- [x] Both workflow YAMLs validated (`yaml.safe_load`)
- [x] `go mod tidy` is a no-op (no toolchain line added)
- [ ] **Self-verifying:** this PR exercises its own fixes — `pull_request` events use the PR-branch workflow files, so the Claude review here runs with the new `write` perms (fix #1 verified if a review appears), the new L4 trigger fires on this PR (fix #2), and the harness `govulncheck` job should stop reporting GO-2026-5856 (fix #3).

## Cross-repo checklist

- [ ] Does this need a docs/content update in `openboot.dev`? — No
- [ ] Does this change the CLI ↔ server API contract? — No

## Notes for reviewer

- Purely in-YAML + go.mod; no repo settings, secrets, or branch-protection changes.
- Fix #1's write escalation only takes effect if the repo/org allows the workflow token to request write — that's the standard default; the review run on this PR is the empirical check.
- Cost note on fix #2: L4 is a ~60-min macOS job (10× minute multiplier) and will now run on every PR. It's non-blocking; if the macOS minutes bite, dial it back with a `paths` filter or drop the trigger.

https://claude.ai/code/session_01HLoiSd2k9EJJ1HPjjDgUgo