### PR TITLE
fix(tui): show select focus without relying on colour

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.0
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/lipgloss v1.0.0
-	github.com/muesli/termenv v0.15.3-0.20240618155329-98d742f6907a
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.11.1
@@ -33,6 +32,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/termenv v0.15.3-0.20240618155329-98d742f6907a // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/internal/ui/tui/wizard/select.go
+++ b/internal/ui/tui/wizard/select.go
@@ -339,10 +339,11 @@ func (m Model) selectSidebar(h int) []string {
 		nameStyle := fg(cDim)
 		countStyle := fg(cDim4)
 		if active {
-			// Bright marker when the sidebar holds focus; muted when the
-			// package list does, so the active pane reads at a glance.
+			// A pointer arrow when the sidebar holds focus vs a plain bar when
+			// it doesn't — a structural cue, so the focused pane reads without
+			// relying on colour (piped output, colourblind users).
 			if m.selFocus == focusCats {
-				edge = fg(cAccent).Render("▎")
+				edge = fg(cAccent).Render("▸")
 				nameStyle = fg(cTextHi)
 			} else {
 				edge = fg(cDim2).Render("▎")
@@ -448,14 +449,10 @@ func (m Model) renderRow(p config.Package, cursor bool, w int) string {
 
 	name := padTo(nameStyle.Render(p.Name), 20)
 	rowPrefix := "  "
-	if cursor {
-		// Dim the cursor when focus is on the sidebar, so the two panes'
-		// cursors don't compete for attention.
-		if listFocused {
-			rowPrefix = fg(cAccent).Render("› ")
-		} else {
-			rowPrefix = fg(cDim3).Render("› ")
-		}
+	if cursor && listFocused {
+		// The cursor arrow shows only when the list holds focus, so exactly one
+		// pane displays a pointer at a time — the focus cue, without colour.
+		rowPrefix = fg(cAccent).Render("› ")
 	}
 	left := rowPrefix + box + "  " + name + " " + fg(cDim).Render(p.Description)
 	return bar(truncCell(left, w-12), tail+" ", w)

--- a/internal/ui/tui/wizard/wizard_test.go
+++ b/internal/ui/tui/wizard/wizard_test.go
@@ -8,7 +8,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -145,20 +144,13 @@ func TestSelectFocusAndCategoryNav(t *testing.T) {
 	assert.Equal(t, 1, m.rowCur, "↓ under list focus advances the package cursor")
 }
 
-// TestSelectFocusIsVisuallyIndicated proves the focus highlight is automatable
-// (contra "you have to eyeball it"): with identical state but different focus,
-// the rendered sidebar and cursor row must differ, because the active pane's
-// marker is styled brighter than the other's. What a test can't judge is
-// whether that difference is *clear enough* to a human — that stays taste.
+// TestSelectFocusIsVisuallyIndicated proves the focus cue survives WITHOUT
+// colour: with identical state but different focus, the sidebar and cursor row
+// differ structurally (the pointer glyph moves to the focused pane), so the
+// indicator holds up in piped output and for colourblind users — and needs no
+// forced colour profile to test. What a test still can't judge is whether the
+// cue is *clear enough* to a human; that stays taste.
 func TestSelectFocusIsVisuallyIndicated(t *testing.T) {
-	// lipgloss strips color when stdout isn't a TTY (as under `go test`), which
-	// would make both focus states render identically — the trap that makes a
-	// naive colour assertion silently test nothing. Force a profile so the test
-	// actually sees the styling; SetColorProfile exists for exactly this.
-	orig := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	defer lipgloss.SetColorProfile(orig)
-
 	m := finishProbes(sized(96, 30))
 	m = send(m, key("c"))
 	require.GreaterOrEqual(t, len(m.pool()), 1)
@@ -170,11 +162,11 @@ func TestSelectFocusIsVisuallyIndicated(t *testing.T) {
 	assert.NotEqual(t,
 		strings.Join(catsFocus.selectSidebar(28), "\n"),
 		strings.Join(listFocus.selectSidebar(28), "\n"),
-		"active category must render differently when the sidebar has focus")
+		"active category marker must differ by focus (structural, not just colour)")
 	assert.NotEqual(t,
 		catsFocus.renderRow(catsFocus.pool()[0], true, 90),
 		listFocus.renderRow(listFocus.pool()[0], true, 90),
-		"cursor row must render differently when the list has focus")
+		"cursor row must differ by focus — the pointer shows only under list focus")
 }
 
 func TestSelectTabTogglesFocus(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds a structural (non-colour) focus cue to the wizard's SELECT screen, so which pane is focused is visible without colour.

## Why?

The two-pane focus indicator from #137 was **colour-only** (bright vs dim) — invisible in piped output, under a dumb `TERM`, or to colourblind users, and untestable without forcing a colour profile. Now the **pointer glyph moves to the focused pane**:

- Category sidebar shows `▸` (arrow) when it holds focus vs `▎` (bar) when it doesn't.
- List cursor `›` shows only under list focus.

Exactly one pointer is visible at a time, so focus reads without colour. Verified by driving the wizard on a tmux pty — the cue is legible in a plain (colour-stripped) `capture-pane`.

## Testing

- [x] `go vet ./...` passes / `make build` OK
- [x] `TestSelectFocusIsVisuallyIndicated` now asserts the **structural** difference and no longer forces a colour profile (so `termenv` drops back to an indirect dep)
- [x] Full wizard unit suite green; visually confirmed on a tmux pty (▸/▎ in the sidebar, `›` appearing/hiding in the list as focus moves)

## Cross-repo checklist

- [ ] Docs/content update in `openboot.dev`? — No
- [ ] CLI ↔ server API contract change? — No

## Notes for reviewer

- Follow-up to #137 (the two-pane focus + mouse work), part of the held v0.64.0.
- Interaction is unchanged — this only changes how focus is *drawn* (glyph moves instead of just colour shifting).

https://claude.ai/code/session_01HLoiSd2k9EJJ1HPjjDgUgo