### PR TITLE
ci: allowlist the tools Claude review needs to post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,12 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # Allowlist the tools the review needs to POST back. Without the
+          # inline-comment MCP tool the run buffers a review then silently drops
+          # it: with pull-requests:read it never reaches the tool (0 denials);
+          # with write it tries and hits the permission gate (1 denial, "No
+          # buffered inline comments"). The gh commands let it read diff/context.
+          claude_args: '--allowed-tools mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## What does this PR do?

Adds `claude_args: --allowed-tools ...` to the Claude Code Review workflow so it can actually post its review.

## Why?

The review workflow completes successfully but posts nothing. The failure mode evolved as we narrowed it:

- Originally `pull-requests: read` → the run never reached the posting tool (`permission_denials_count: 0`), logged `No buffered inline comments`, posted nothing.
- #136 granted `pull-requests`/`issues: write` → the run now **tries** to post and hits `permission_denials_count: 1`, still `No buffered inline comments`.

That 1 denial is the `/code-review` plugin calling `mcp__github_inline_comment__create_inline_comment`, which isn't in the action's default allowlist. This PR allowlists it, plus the `gh pr diff/view/comment` commands the review reads context with. Write permission (#136) was necessary; the allowlist is the missing second half.

Auth (`claude_code_oauth_token`) and the `/code-review` plugin prompt are unchanged — the logs show both already work.

## Testing

- [x] YAML validated (`yaml.safe_load`)
- [ ] **Cannot self-verify:** `claude-code-action` skips its run on any PR that edits its own workflow file (anti-tamper guard — we observed this on #136). This fix activates on the **next** PR that doesn't touch the workflow; that PR's `claude-review` run should show `permission_denials_count: 0` and an actual posted review.

## Cross-repo checklist

- [ ] Docs/content update in `openboot.dev`? — No
- [ ] CLI ↔ server API contract change? — No

## Notes for reviewer

- `.github/workflows/` change — no repo settings/secrets touched; the tool allowlist is the only change.
- Diagnosis is docs-backed (claude-code-action's `github-inline-comment-server.ts` + issue #548) and consistent with the observed 0→1 denial transition.

https://claude.ai/code/session_01HLoiSd2k9EJJ1HPjjDgUgo