### PR TITLE
fix: address Codex review findings (auth gate + wizard install)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude:
+    # Only fire for the repo's own maintainers. Without the author_association
+    # gate, on a public repo any external user could post "@claude" and run this
+    # secret-backed workflow (CLAUDE_CODE_OAUTH_TOKEN is available to the job).
+    # OWNER/MEMBER/COLLABORATOR are the trusted actors.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -175,14 +175,18 @@ func shouldLaunchWizard(src *installSource) bool {
 func runInstallWizard() error {
 	opts := installCfg.ToInstallOptions()
 	plan, confirmed, err := wizard.Run(installCfg.Version, opts)
+	// Show the screen-recording reminder for any install that actually ran —
+	// including one that ended in a soft error (e.g. a cask installed, then
+	// dotfiles failed), matching the linear installer. Skip it only on a user
+	// abort, where nagging would be noise.
+	if confirmed && !errors.Is(err, wizard.ErrAborted) {
+		installer.ShowScreenRecordingReminderAfterTUI(plan)
+	}
 	if err != nil {
 		if errors.Is(err, wizard.ErrAborted) {
 			return fmt.Errorf("installation aborted — partially applied changes are logged in ~/.openboot/logs")
 		}
 		return fmt.Errorf("install wizard: %w", err)
-	}
-	if confirmed {
-		installer.ShowScreenRecordingReminderAfterTUI(plan)
 	}
 	return nil
 }

--- a/internal/ui/tui/wizard/select.go
+++ b/internal/ui/tui/wizard/select.go
@@ -285,8 +285,11 @@ func (m Model) selectHitTest(x, y int) (selHit, int) {
 }
 
 func (m Model) tryInstall() (tea.Model, tea.Cmd) {
-	if m.toInstallCount() == 0 {
-		return m, nil // nothing to install — stay put
+	// Gate on a selection, not on new packages: an all-installed loadout still
+	// carries git/shell/dotfiles/macOS steps worth reviewing and applying, so
+	// zero *new* packages must not trap the user on the select screen.
+	if m.selCount() == 0 {
+		return m, nil // nothing selected — stay put
 	}
 	// Capture a git identity first when none is configured (fresh Mac), then
 	// review the full plan before anything runs.

--- a/internal/ui/tui/wizard/wizard.go
+++ b/internal/ui/tui/wizard/wizard.go
@@ -333,11 +333,16 @@ func truncCell(s string, w int) string {
 func Run(version string, opts *config.InstallOptions) (plan installer.InstallPlan, confirmed bool, err error) {
 	m := New(version, opts)
 
-	realOut := os.Stdout
+	// While the alt-screen is up, redirect BOTH stdout and stderr away from the
+	// terminal: the install engine's subprocesses (git clone, stow, chsh…) write
+	// progress to os.Stderr, which would otherwise paint over Bubble Tea's
+	// full-screen UI. The engine's own output reaches the wizard via the event
+	// channel; the terminal it renders to is realOut (WithOutput below).
+	realOut, realErr := os.Stdout, os.Stderr
 	if devnull, derr := os.OpenFile(os.DevNull, os.O_WRONLY, 0); derr == nil {
-		os.Stdout = devnull
+		os.Stdout, os.Stderr = devnull, devnull
 		defer func() {
-			os.Stdout = realOut
+			os.Stdout, os.Stderr = realOut, realErr
 			_ = devnull.Close()
 		}()
 	}

--- a/internal/ui/tui/wizard/wizard_test.go
+++ b/internal/ui/tui/wizard/wizard_test.go
@@ -243,7 +243,28 @@ func TestTryInstallNoopWhenNothingToInstall(t *testing.T) {
 	m := finishProbes(sized(96, 30))
 	m = send(m, key("c")) // empty selection
 	m = send(m, key("enter"))
-	assert.Equal(t, scrSelect, m.screen, "enter with nothing to install stays on select")
+	assert.Equal(t, scrSelect, m.screen, "enter with nothing selected stays on select")
+}
+
+// An all-installed loadout has zero *new* packages but still carries config
+// steps (git/shell/dotfiles/macOS); Enter must reach review, not trap the user.
+func TestSelectAllInstalledLoadoutStillProceeds(t *testing.T) {
+	defer stubGitConfig("Jane Dev", "jane@ex.io")() // configured → skip git capture
+	m := finishProbes(sized(96, 30))
+	m = send(m, key("2")) // developer loadout populates the selection
+	require.Positive(t, m.selCount())
+
+	// Mark every selected package as already present: 0 new, selection non-empty.
+	m.installed = map[string]bool{}
+	for name, on := range m.selected {
+		if on {
+			m.installed[name] = true
+		}
+	}
+	require.Zero(t, m.toInstallCount(), "precondition: nothing new to install")
+
+	m = send(m, key("enter"))
+	assert.Equal(t, scrConfirm, m.screen, "an all-installed loadout must still reach review")
 }
 
 func TestGitCaptureWhenUnconfigured(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Fixes four issues a Codex review flagged in the v0.64.0 range — one security hardening on the `@claude` workflow and three install-wizard correctness bugs. Each finding was verified against the code before fixing; one flagged item was a false positive and is intentionally not changed (see below).

## Why?

- **[P1] `ci: gate @claude workflow to trusted actors`** — `claude.yml`'s `if:` only checked for `@claude` in the body, with no author gate. On a public repo, any external user commenting on an issue/PR could trigger this secret-backed workflow (`CLAUDE_CODE_OAUTH_TOKEN` is available to the job). Now requires `author_association ∈ OWNER/MEMBER/COLLABORATOR`.
- **[P2] `fix(tui): redirect stderr while the install wizard owns the terminal`** — `wizard.Run` redirected `os.Stdout` to `/dev/null` for the alt-screen but left `os.Stderr` on the real terminal. Install subprocesses (`git clone`, `stow`, `chsh`) write progress to stderr, painting over the full-screen UI. Now redirects/restores stderr too.
- **[P2] `fix(tui): let all-installed loadouts reach the review screen`** — `tryInstall` gated on `toInstallCount() == 0`, so a loadout whose packages are all installed left Enter doing nothing, trapping the user even though the plan still carries git/shell/dotfiles/macOS steps. Now gates on `selCount()`. Regression test added.
- **[P3] `fix(cli): show screen-recording reminder even after soft errors`** — `runInstallWizard` only ran the reminder on a nil error, so a confirmed install that set up a screen-recording app (e.g. Zoom) then hit a soft error skipped the permission guidance — unlike the linear installer. Now shows it whenever the install was confirmed and not aborted.

**Rejected as a false positive (not changed):** Codex flagged that `replay()` (the DONE-screen `r` key) doesn't re-schedule `tickCmd`, freezing spinners. It doesn't: the `tickMsg` handler unconditionally returns `tickCmd()`, so the tick loop is self-sustaining and survives replay via the in-flight command. Adding `tickCmd()` there would create a second tick chain (double-speed spinner/clock), so it's deliberately left alone.

## Testing

- [x] `go vet ./...` passes
- [x] New regression test `TestSelectAllInstalledLoadoutStillProceeds`; full wizard/cli/installer suites + archtest green; `make build` OK; `claude.yml` YAML validated
- [ ] **No unit test for [P2-stderr] / [P3-reminder]:** the stderr redirect only manifests in a real TUI (covered by L3/L4 pty tests), and `runInstallWizard` needs a TTY to reach; both changes are small and hand-verified but not mechanically locked.

## Cross-repo checklist

- [ ] Docs/content update in `openboot.dev`? — No
- [ ] CLI ↔ server API contract change? — No

## Notes for reviewer

- `.github/workflows/claude.yml` is a security-policy change: `OWNER/MEMBER/COLLABORATOR` is the standard trusted set (you, the owner, are unaffected). Adjust if you want to allow specific external collaborators or require approval.
- Part of the held v0.64.0.

https://claude.ai/code/session_01HLoiSd2k9EJJ1HPjjDgUgo