### PR TITLE
fix(ci): use explicit token auth for homebrew-tap push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,8 @@ jobs:
           sed -i 's/^          //' homebrew-tap/Formula/openboot.rb
 
       - name: Commit and push
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           cd homebrew-tap
           git config user.name "github-actions[bot]"
@@ -275,4 +277,5 @@ jobs:
           git add Formula/openboot.rb
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "chore: bump openboot to ${{ needs.detect-release-type.outputs.version_clean }}"
+          git remote set-url origin "https://x-access-token:${TAP_TOKEN}@github.com/openbootdotdev/homebrew-tap.git"
           git push


### PR DESCRIPTION
## What does this PR do?

Fixes the `update-homebrew-tap` job in `release.yml` that failed on v0.64.0.

## Why?

The job's `git push` failed with `fatal: could not read Username for 'https://github.com'`. The root cause is that it relied on `actions/checkout@v4`'s `extraheader` side-effect to authenticate the push — this worked for v0.61–v0.63 but broke on v0.64.0 even though `release.yml` didn't change. The most likely explanation is a runner image or checkout action patch bump that altered credential persistence.

The fix makes auth explicit: `git remote set-url origin "https://x-access-token:${TAP_TOKEN}@github.com/..."` before `git push`, so the token is in the URL rather than relying on the checkout action's internal behaviour.

## Testing

- [x] YAML validated
- [ ] **Cannot dry-run** — this only runs on an actual release tag push. The next release (v0.65.0 or a re-tag) will verify it.

## Cross-repo checklist

- [ ] Docs/content update? — No
- [ ] CLI ↔ server API contract? — No

## Notes for reviewer

- One-line logic change + env var to expose the secret (already in repo secrets, last rotated 2026-06-09).
- If this fix works on the next release, we can also manually push the v0.64.0 formula update that was missed.

https://claude.ai/code/session_01HLoiSd2k9EJJ1HPjjDgUgo