### PR TITLE
feat(tui): run sync-source install through the wizard pipeline UI

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"github.com/openbootdotdev/openboot/internal/auth"
 	"github.com/openbootdotdev/openboot/internal/config"
 	"github.com/openbootdotdev/openboot/internal/installer"
+	"github.com/openbootdotdev/openboot/internal/progress"
 	syncpkg "github.com/openbootdotdev/openboot/internal/sync"
 	"github.com/openbootdotdev/openboot/internal/system"
 	"github.com/openbootdotdev/openboot/internal/ui"
@@ -408,25 +410,65 @@ func runSyncInstall(source *syncpkg.SyncSource, pickRaw string) error { //nolint
 		}
 	}
 
-	ui.Println()
 	plan := buildInstallPlan(diff, rc)
-	result, execErr := syncpkg.Execute(plan, false)
 
-	ui.Println()
-	if result.Installed > 0 {
-		ui.Success(fmt.Sprintf("Installed %d package(s)", result.Installed))
+	// Apply through the wizard's live pipeline screen (on a TTY) so the sync
+	// install shares the full-screen streaming visuals; fall back to the linear
+	// Execute + printed summary when there's no TTY (scripts, piped output).
+	var result *syncpkg.SyncResult
+	run := func(context.Context) error {
+		var err error
+		result, err = syncpkg.Execute(plan, false)
+		return err
 	}
-	if result.Updated > 0 {
-		ui.Success(fmt.Sprintf("Updated %d setting(s)", result.Updated))
-	}
-	for _, e := range result.Errors {
-		ui.Error(fmt.Sprintf("Failed: %s", e))
+	var execErr error
+	if !installCfg.Silent && system.HasTTY() {
+		execErr = wizard.RunPipeline(installCfg.Version, syncPipelinePhases(plan), run)
+	} else {
+		ui.Println()
+		execErr = run(context.Background())
+		ui.Println()
+		if result.Installed > 0 {
+			ui.Success(fmt.Sprintf("Installed %d package(s)", result.Installed))
+		}
+		if result.Updated > 0 {
+			ui.Success(fmt.Sprintf("Updated %d setting(s)", result.Updated))
+		}
+		for _, e := range result.Errors {
+			ui.Error(fmt.Sprintf("Failed: %s", e))
+		}
 	}
 
-	if execErr == nil || result.Installed > 0 || result.Updated > 0 {
+	if result != nil && (execErr == nil || result.Installed > 0 || result.Updated > 0) {
 		updateSyncedAt(source, "", rc)
 	}
 	return execErr
+}
+
+// syncPipelinePhases derives the wizard pipeline sidebar from a sync plan.
+// Taps run but aren't shown (they emit no per-item progress); config steps
+// (dotfiles/shell/macOS) show as single rows that complete when Execute returns.
+func syncPipelinePhases(p *syncpkg.SyncPlan) []wizard.PipelinePhase {
+	var ps []wizard.PipelinePhase
+	if n := len(p.InstallFormulae); n > 0 {
+		ps = append(ps, wizard.PipelinePhase{Name: progress.PhaseHomebrew, Total: n, Pkg: true})
+	}
+	if n := len(p.InstallCasks); n > 0 {
+		ps = append(ps, wizard.PipelinePhase{Name: progress.PhaseApplications, Total: n, Pkg: true})
+	}
+	if n := len(p.InstallNpm); n > 0 {
+		ps = append(ps, wizard.PipelinePhase{Name: progress.PhaseNpm, Total: n, Pkg: true})
+	}
+	if p.UpdateDotfiles != "" {
+		ps = append(ps, wizard.PipelinePhase{Name: "Dotfiles", Total: 1})
+	}
+	if p.UpdateShell {
+		ps = append(ps, wizard.PipelinePhase{Name: "Shell", Total: 1})
+	}
+	if len(p.UpdateMacOSPrefs) > 0 {
+		ps = append(ps, wizard.PipelinePhase{Name: "macOS prefs", Total: 1})
+	}
+	return ps
 }
 
 // printSyncSourceHeader shows the "→ Syncing with X (last synced Y)" line at

--- a/internal/cli/sync_helpers_test.go
+++ b/internal/cli/sync_helpers_test.go
@@ -275,3 +275,33 @@ func TestUpdateSyncedAt_ZeroInstalledAt_UseNow(t *testing.T) {
 	assert.True(t, !loaded.InstalledAt.Before(before.Add(-time.Second)), "InstalledAt should be recent")
 	assert.True(t, !loaded.InstalledAt.After(after.Add(time.Second)), "InstalledAt should be recent")
 }
+
+// ── syncPipelinePhases ────────────────────────────────────────────────────────
+
+func TestSyncPipelinePhases(t *testing.T) {
+	plan := &syncpkg.SyncPlan{
+		InstallFormulae:  []string{"jq", "ripgrep"},
+		InstallCasks:     []string{"orbstack"},
+		InstallTaps:      []string{"some/tap"}, // runs, but not shown as a phase
+		UpdateDotfiles:   "https://github.com/x/dotfiles",
+		UpdateMacOSPrefs: []config.RemoteMacOSPref{{Key: "a"}, {Key: "b"}},
+		// no npm, no shell
+	}
+	ps := syncPipelinePhases(plan)
+
+	require.Len(t, ps, 4, "Homebrew, Applications, Dotfiles, macOS prefs — taps and npm/shell excluded")
+	assert.Equal(t, "Homebrew", ps[0].Name)
+	assert.Equal(t, 2, ps[0].Total)
+	assert.True(t, ps[0].Pkg)
+	assert.Equal(t, "Applications", ps[1].Name)
+	assert.True(t, ps[1].Pkg)
+	assert.Equal(t, "Dotfiles", ps[2].Name)
+	assert.Equal(t, 1, ps[2].Total)
+	assert.False(t, ps[2].Pkg, "config steps are not per-item package phases")
+	assert.Equal(t, "macOS prefs", ps[3].Name)
+	assert.Equal(t, 1, ps[3].Total)
+}
+
+func TestSyncPipelinePhasesEmpty(t *testing.T) {
+	assert.Empty(t, syncPipelinePhases(&syncpkg.SyncPlan{}), "an empty plan yields no phases")
+}

--- a/internal/ui/tui/wizard/install.go
+++ b/internal/ui/tui/wizard/install.go
@@ -126,6 +126,41 @@ func (m Model) spawnInstall(ctx context.Context, plan installer.InstallPlan) tea
 	}
 }
 
+// PipelinePhase describes one row of the install pipeline for RunPipeline. Use
+// the progress.Phase* names for package phases so streamed events line up.
+type PipelinePhase struct {
+	Name  string
+	Total int
+	Pkg   bool // true for per-item package phases (brew/cask/npm)
+}
+
+func toPhaseStates(ps []PipelinePhase) []phaseState {
+	out := make([]phaseState, len(ps))
+	for i, p := range ps {
+		out[i] = phaseState{name: p.Name, total: p.Total, pkg: p.Pkg}
+	}
+	return out
+}
+
+// startPipeline runs an externally-supplied plan (RunPipeline / sync-source
+// path) on a goroutine, wiring the same brew/npm sinks as spawnInstall so
+// package progress streams into the shared install screen.
+func (m Model) startPipeline() tea.Cmd {
+	ch, run, ctx := m.events, m.pipelineRun, m.pipelineCtx
+	return func() tea.Msg {
+		go func() {
+			sink := func(ev progress.Event) { ch <- evMsg{ev: ev} }
+			restoreBrew := brew.SetProgressSink(sink)
+			restoreNpm := npm.SetProgressSink(sink)
+			err := run(ctx)
+			restoreBrew()
+			restoreNpm()
+			ch <- installDoneMsg{err: err}
+		}()
+		return nil
+	}
+}
+
 // buildPhases derives the pipeline sidebar from the plan. Package-phase totals
 // count every planned package: the engine's streaming invariant is that each
 // one produces exactly one terminal event (installed, failed, or
@@ -355,7 +390,9 @@ func (m Model) updateInstall(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.done {
 		switch msg.String() {
 		case "r":
-			return m.replay()
+			if m.pipelineRun == nil { // replay is a wizard-only action
+				return m.replay()
+			}
 		case "q", "enter", "esc":
 			return m, tea.Quit
 		}

--- a/internal/ui/tui/wizard/wizard.go
+++ b/internal/ui/tui/wizard/wizard.go
@@ -104,6 +104,10 @@ type Model struct {
 	skippedPkgs int // terminal events with SkipDetail (already installed)
 	installTick int // ticks value when install started, for elapsed
 	cancel      context.CancelFunc
+
+	// ── pipeline mode (RunPipeline: sync-source install reuses this screen) ──
+	pipelineRun func(context.Context) error // non-nil ⇒ start on the install screen
+	pipelineCtx context.Context
 }
 
 // New builds a wizard model for the given version and resolved install options.
@@ -123,6 +127,9 @@ func New(version string, opts *config.InstallOptions) Model {
 }
 
 func (m Model) Init() tea.Cmd {
+	if m.pipelineRun != nil {
+		return tea.Batch(tickCmd(), m.startPipeline())
+	}
 	return tea.Batch(tickCmd(), m.runProbe(0))
 }
 
@@ -349,19 +356,8 @@ func truncCell(s string, w int) string {
 func Run(version string, opts *config.InstallOptions) (plan installer.InstallPlan, confirmed bool, err error) {
 	m := New(version, opts)
 
-	// While the alt-screen is up, redirect BOTH stdout and stderr away from the
-	// terminal: the install engine's subprocesses (git clone, stow, chsh…) write
-	// progress to os.Stderr, which would otherwise paint over Bubble Tea's
-	// full-screen UI. The engine's own output reaches the wizard via the event
-	// channel; the terminal it renders to is realOut (WithOutput below).
-	realOut, realErr := os.Stdout, os.Stderr
-	if devnull, derr := os.OpenFile(os.DevNull, os.O_WRONLY, 0); derr == nil {
-		os.Stdout, os.Stderr = devnull, devnull
-		defer func() {
-			os.Stdout, os.Stderr = realOut, realErr
-			_ = devnull.Close()
-		}()
-	}
+	realOut, restore := redirectOutput()
+	defer restore()
 
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseAllMotion(), tea.WithOutput(realOut), tea.WithInput(os.Stdin))
 	final, runErr := p.Run()
@@ -370,4 +366,46 @@ func Run(version string, opts *config.InstallOptions) (plan installer.InstallPla
 	}
 	fm := final.(Model)
 	return fm.plan, fm.confirmed, fm.installErr
+}
+
+// redirectOutput sends stdout+stderr to /dev/null for the alt-screen's lifetime
+// (subprocess progress must not paint over Bubble Tea) and returns the real
+// stdout to render onto plus a restore func.
+func redirectOutput() (realOut *os.File, restore func()) {
+	realOut, realErr := os.Stdout, os.Stderr
+	if devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0); err == nil {
+		os.Stdout, os.Stderr = devnull, devnull
+		return realOut, func() {
+			os.Stdout, os.Stderr = realOut, realErr
+			_ = devnull.Close()
+		}
+	}
+	return realOut, func() {}
+}
+
+// RunPipeline renders the wizard's live install screen for an externally-built
+// plan, so the sync-source path (install <slug>) shares the wizard's install
+// visuals instead of the linear StickyProgress. phases seed the pipeline
+// sidebar; run does the work on a goroutine, its package progress streaming
+// through the brew/npm sinks RunPipeline registers. Returns run's error
+// (ErrAborted on ctrl+c).
+func RunPipeline(version string, phases []PipelinePhase, run func(context.Context) error) error {
+	m := New(version, &config.InstallOptions{Version: version})
+	m.screen = scrInstall
+	m.installing = true
+	m.phases = toPhaseStates(phases)
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is stored on the model and called on ctrl+c / done
+	m.cancel = cancel
+	m.pipelineCtx = ctx
+	m.pipelineRun = run
+
+	realOut, restore := redirectOutput()
+	defer restore()
+
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseAllMotion(), tea.WithOutput(realOut), tea.WithInput(os.Stdin))
+	final, runErr := p.Run()
+	if runErr != nil {
+		return fmt.Errorf("run install: %w", runErr)
+	}
+	return final.(Model).installErr
 }

--- a/internal/ui/tui/wizard/wizard_test.go
+++ b/internal/ui/tui/wizard/wizard_test.go
@@ -663,3 +663,32 @@ func logTexts(ls []logLine) []string {
 	}
 	return out
 }
+
+// Pipeline mode (RunPipeline / sync-source path) reuses the install screen with
+// externally-built phases; installDoneMsg must mark it done and, on a clean run,
+// check-mark all phases.
+func TestPipelineModeReachesDone(t *testing.T) {
+	m := New("1.0.0", &config.InstallOptions{})
+	m.screen = scrInstall
+	m.installing = true
+	m.phases = toPhaseStates([]PipelinePhase{
+		{Name: "Homebrew", Total: 2, Pkg: true},
+		{Name: "macOS prefs", Total: 1},
+	})
+
+	m = send(m, installDoneMsg{err: nil})
+	assert.True(t, m.done, "installDoneMsg marks the screen done")
+	assert.False(t, m.installing)
+	for _, p := range m.phases {
+		assert.True(t, p.finished, "a clean run check-marks every phase (incl. config steps)")
+	}
+}
+
+func TestPipelineReplayDisabled(t *testing.T) {
+	m := New("1.0.0", &config.InstallOptions{})
+	m.screen, m.done = scrInstall, true
+	m.pipelineRun = func(context.Context) error { return nil } // marks pipeline mode
+	next, _ := m.Update(key("r"))
+	// 'r' must NOT restart the wizard probe in pipeline mode — screen stays put.
+	assert.Equal(t, scrInstall, next.(Model).screen, "replay is a no-op in pipeline mode")
+}


### PR DESCRIPTION
## What does this PR do?

Makes `install <slug>` (applying a published config) run its install through the wizard's full-screen streaming pipeline, instead of the old linear StickyProgress — so both install paths share one visual language.

## Why?

`install` (bare) used the full-screen wizard; `install <slug>` used the linear sync flow — same product, two different install looks. The right fix (discussed with the maintainer) is to **unify the presentation of the shared stages, not the routing**: picking-vs-applying is a genuine semantic difference, so the sync path keeps its own diff + "Apply?" confirm, but the *install execution* now looks like the wizard.

- **`wizard.RunPipeline(version, phases, run)`** — renders the existing install screen for an externally-built plan, wiring the same brew/npm progress sinks so package progress streams. `redirectOutput()` extracted and shared with `Run()`.
- **`runSyncInstall`** builds pipeline phases from the `SyncPlan` and applies via `RunPipeline` on a TTY; non-TTY / `--silent` keep the linear printed summary.

## Scope note

Package phases stream live (sink already wired). Config steps (dotfiles/shell/macOS) render as pipeline rows that check-mark on completion — live per-step spinners for those are a deliberate follow-up (needs progress emission inside `sync.Execute`, which also currently ignores ctx). This PR is the visual unification; the config-step streaming is additive.

## Testing

- [x] `go vet ./...`, full `internal/...` suite, archtest, `make build` all green
- [x] Unit tests: `syncPipelinePhases` mapping (incl. taps/npm/shell exclusion), pipeline-mode `installDoneMsg` handling, replay disabled in pipeline mode
- [x] `install <slug> --dry-run` confirmed still routes through the sync diff+prompt (dry-run returns before execute, unchanged)
- [ ] Full-screen streaming visual is the wizard's own install screen (already tmux-verified for the wizard path); the new code seeds it — a real `install <slug>` on a TTY exercises it end-to-end

## Cross-repo checklist

- [ ] Docs/content update in `openboot.dev`? — No
- [ ] CLI ↔ server API contract change? — No

## Notes for reviewer

- No import cycle: `RunPipeline` takes a neutral `PipelinePhase`; the CLI (which imports both) builds phases from the `SyncPlan`.
- Pushed over HTTPS (gh token) — local SSH auth was down.

https://claude.ai/code/session_01HLoiSd2k9EJJ1HPjjDgUgo