### PR TITLE
feat(tui): stream slug/preset installs through the wizard pipeline

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -102,7 +102,7 @@ func applyEnvOverrides(cfg *config.Config) {
 	}
 }
 
-func runInstallCmd(cmd *cobra.Command, args []string) error {
+func runInstallCmd(cmd *cobra.Command, args []string) error { //nolint:gocyclo // top-level install dispatch: routes source (sync / wizard / RemoteConfig) × mode (pick / silent / dry-run / TTY-pipeline / linear); splitting the branch table scatters the flow
 	applyEnvOverrides(installCfg)
 
 	if installCfg.RemoteConfig == nil {
@@ -151,6 +151,13 @@ func runInstallCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--pick requires a remote config; use the preset selector instead")
 	}
 
+	// On a TTY, stream the apply through the wizard's live pipeline so a slug /
+	// preset / RemoteConfig install shares the full-screen visuals instead of
+	// the linear "Step N" output. Non-interactive runs keep RunContext.
+	if !installCfg.Silent && !installCfg.DryRun && !installCfg.Update && system.HasTTY() {
+		return runPipelineInstall(cmd.Context())
+	}
+
 	err := installer.RunContext(cmd.Context(), installCfg)
 	if errors.Is(err, installer.ErrUserCancelled) {
 		return nil
@@ -168,6 +175,39 @@ func runInstallCmd(cmd *cobra.Command, args []string) error {
 func shouldLaunchWizard(src *installSource) bool {
 	return src.kind == sourceNone && !installCfg.Silent && !installCfg.DryRun &&
 		!installCfg.Update && system.HasTTY()
+}
+
+// runPipelineInstall resolves the plan (with linear pre-flight prep) and applies
+// it through the wizard's live pipeline screen, so a slug/preset/RemoteConfig
+// install streams like the wizard. ApplyContext is the same engine RunContext
+// uses; only the reporter differs. Follow-ups that can't run inside the
+// alt-screen (screen-recording reminder) happen after, on a normal terminal.
+func runPipelineInstall(ctx context.Context) error {
+	plan, err := installer.PlanForConfig(installCfg)
+	if err != nil {
+		if errors.Is(err, installer.ErrUserCancelled) {
+			return nil
+		}
+		return err
+	}
+	// Silence keeps the in-apply reminder/prompts out of the alt-screen; it's
+	// re-run afterwards via ShowScreenRecordingReminderAfterTUI.
+	plan.Silent = true
+
+	runErr := wizard.RunPipeline(installCfg.Version, wizard.PhasesForPlan(plan),
+		func(ctx context.Context, r installer.Reporter) error {
+			return installer.ApplyContext(ctx, plan, r)
+		})
+	if errors.Is(runErr, wizard.ErrAborted) || errors.Is(runErr, context.Canceled) {
+		return fmt.Errorf("installation aborted — partially applied changes are logged in ~/.openboot/logs")
+	}
+	// The install ran (cleanly or with soft errors): show the reminder on the
+	// restored terminal, then persist the sync source on a clean run.
+	installer.ShowScreenRecordingReminderAfterTUI(plan)
+	if runErr == nil {
+		saveSyncSourceIfRemote(installCfg)
+	}
+	return runErr
 }
 
 // runInstallWizard launches the full-screen install TUI and runs the resulting
@@ -420,7 +460,7 @@ func runSyncInstall(source *syncpkg.SyncSource, pickRaw string) error { //nolint
 	// step-errors surface as that error, so a config-step failure isn't hidden.
 	if !installCfg.Silent && system.HasTTY() {
 		execErr := wizard.RunPipeline(installCfg.Version, syncPipelinePhases(plan),
-			func(ctx context.Context) error {
+			func(ctx context.Context, _ installer.Reporter) error {
 				_, err := syncpkg.ExecuteContext(ctx, plan, false)
 				return err
 			})

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -84,6 +84,23 @@ func runInstallContext(ctx context.Context, opts *config.InstallOptions, st *con
 	return ApplyContext(ctx, plan, ConsoleReporter{})
 }
 
+// PlanForConfig runs the pre-flight dependency check and resolves the install
+// plan for cfg — the linear RunContext flow up to (but not including) Apply. It
+// exists so the wizard pipeline can do the interactive prep on a normal
+// terminal, then stream the apply itself via ApplyContext with its own Reporter.
+func PlanForConfig(cfg *config.Config) (InstallPlan, error) {
+	opts := cfg.ToInstallOptions()
+	st := cfg.ToInstallState()
+	if err := checkDependencies(opts, st); err != nil {
+		return InstallPlan{}, fmt.Errorf("check dependencies: %w", err)
+	}
+	plan, err := Plan(opts, st)
+	if err != nil {
+		return InstallPlan{}, fmt.Errorf("plan install: %w", err)
+	}
+	return plan, nil
+}
+
 // Apply executes a resolved InstallPlan, reporting progress via r.
 // All user interaction has already happened in Plan(); this function only performs actions.
 func Apply(plan InstallPlan, r Reporter) error {

--- a/internal/ui/tui/wizard/install.go
+++ b/internal/ui/tui/wizard/install.go
@@ -152,13 +152,28 @@ func (m Model) startPipeline() tea.Cmd {
 			sink := func(ev progress.Event) { ch <- evMsg{ev: ev} }
 			restoreBrew := brew.SetProgressSink(sink)
 			restoreNpm := npm.SetProgressSink(sink)
-			err := run(ctx)
+			// chanReporter feeds section headers (→ phase activation) and outcome
+			// log lines onto the same channel, so an ApplyContext-based run
+			// streams exactly like the wizard's own install.
+			err := run(ctx, chanReporter{ch: ch})
 			restoreBrew()
 			restoreNpm()
 			ch <- installDoneMsg{err: err}
 		}()
 		return nil
 	}
+}
+
+// PhasesForPlan derives pipeline phases from a resolved installer plan, so a
+// RemoteConfig/preset install (install <slug>) can drive RunPipeline with the
+// same sidebar the wizard builds.
+func PhasesForPlan(plan installer.InstallPlan) []PipelinePhase {
+	ps := buildPhases(plan)
+	out := make([]PipelinePhase, len(ps))
+	for i, p := range ps {
+		out[i] = PipelinePhase{Name: p.name, Total: p.total, Pkg: p.pkg}
+	}
+	return out
 }
 
 // buildPhases derives the pipeline sidebar from the plan. Package-phase totals

--- a/internal/ui/tui/wizard/wizard.go
+++ b/internal/ui/tui/wizard/wizard.go
@@ -105,8 +105,8 @@ type Model struct {
 	installTick int // ticks value when install started, for elapsed
 	cancel      context.CancelFunc
 
-	// ── pipeline mode (RunPipeline: sync-source install reuses this screen) ──
-	pipelineRun func(context.Context) error // non-nil ⇒ start on the install screen
+	// ── pipeline mode (RunPipeline: sync-source & slug installs reuse this screen) ──
+	pipelineRun func(context.Context, installer.Reporter) error // non-nil ⇒ start on install screen
 	pipelineCtx context.Context
 }
 
@@ -399,7 +399,7 @@ func redirectOutput() (realOut *os.File, restore func()) {
 // sidebar; run does the work on a goroutine, its package progress streaming
 // through the brew/npm sinks RunPipeline registers. Returns run's error
 // (ErrAborted on ctrl+c).
-func RunPipeline(version string, phases []PipelinePhase, run func(context.Context) error) error {
+func RunPipeline(version string, phases []PipelinePhase, run func(context.Context, installer.Reporter) error) error {
 	m := New(version, &config.InstallOptions{Version: version})
 	m.screen = scrInstall
 	m.installing = true

--- a/internal/ui/tui/wizard/wizard_test.go
+++ b/internal/ui/tui/wizard/wizard_test.go
@@ -679,7 +679,7 @@ func TestPipelineDrainsChannelAndCompletes(t *testing.T) {
 	m.screen, m.installing = scrInstall, true
 	m.phases = toPhaseStates([]PipelinePhase{{Name: "Homebrew", Total: 1, Pkg: true}})
 	m.pipelineCtx = context.Background()
-	m.pipelineRun = func(context.Context) error { return nil } // completes instantly
+	m.pipelineRun = func(context.Context, installer.Reporter) error { return nil } // completes instantly
 
 	p := tea.NewProgram(m, tea.WithInput(pr), tea.WithOutput(io.Discard), tea.WithoutRenderer())
 	done := make(chan tea.Model, 1)
@@ -720,8 +720,32 @@ func TestPipelineModeReachesDone(t *testing.T) {
 func TestPipelineReplayDisabled(t *testing.T) {
 	m := New("1.0.0", &config.InstallOptions{})
 	m.screen, m.done = scrInstall, true
-	m.pipelineRun = func(context.Context) error { return nil } // marks pipeline mode
+	m.pipelineRun = func(context.Context, installer.Reporter) error { return nil } // marks pipeline mode
 	next, _ := m.Update(key("r"))
 	// 'r' must NOT restart the wizard probe in pipeline mode — screen stays put.
 	assert.Equal(t, scrInstall, next.(Model).screen, "replay is a no-op in pipeline mode")
+}
+
+// PhasesForPlan drives the slug/preset pipeline sidebar from an installer plan.
+func TestPhasesForPlan(t *testing.T) {
+	plan := installer.InstallPlan{
+		Formulae:       []string{"jq", "ripgrep"},
+		Casks:          []string{"orbstack"},
+		InstallOhMyZsh: true,
+		DotfilesURL:    "https://github.com/x/dotfiles",
+	}
+	ps := PhasesForPlan(plan)
+
+	byName := map[string]PipelinePhase{}
+	for _, p := range ps {
+		byName[p.Name] = p
+	}
+	require.Contains(t, byName, "Homebrew")
+	assert.Equal(t, 2, byName["Homebrew"].Total)
+	assert.True(t, byName["Homebrew"].Pkg)
+	require.Contains(t, byName, "Applications")
+	require.Contains(t, byName, "Shell")
+	assert.False(t, byName["Shell"].Pkg, "config steps are not per-item package phases")
+	require.Contains(t, byName, "Dotfiles")
+	assert.NotContains(t, byName, "npm globals", "no npm in this plan")
 }


### PR DESCRIPTION
## What does this PR do?

Makes `install <slug>` / `install <preset>` apply through the wizard's full-screen streaming pipeline instead of the linear "OpenBoot Installer / Step N" output — the real fix for "this UI is still old".

## Why?

`install <slug>` resolves to a RemoteConfig and applied through `installer.RunContext` (linear). The earlier #143 unified `runSyncInstall` — a **different** path (the saved sync-source flow), which slug installs don't take. So the slug UI stayed old.

`installer.ApplyContext` is the same engine both the wizard and RunContext already use — only the reporter differs (ConsoleReporter vs the wizard's channel reporter). On a TTY we now resolve the plan with the linear pre-flight (`installer.PlanForConfig`: `checkDependencies` + `Plan`), then apply it via `wizard.RunPipeline` with a `chanReporter`. The installer's section headers ("Step 1: Git Configuration", "Step 4: Installation", …) already map to pipeline phases via the wizard's `headerPhase`, so it streams identically to the wizard.

- `installer.PlanForConfig(cfg)` — the RunContext flow up to (not including) apply.
- `wizard.RunPipeline`'s run closure now receives an `installer.Reporter`; `wizard.PhasesForPlan` seeds the sidebar from an `InstallPlan`.
- `runPipelineInstall` wires it, mirroring the wizard's abort / screen-recording-reminder / save-sync-source handling.
- Non-TTY / `--silent` / `--dry-run` keep `RunContext` (linear) unchanged.

## Testing

- [x] `go vet ./...`, full `internal/...` suite, `go test -race` (wizard), `make build` — green
- [x] `TestPhasesForPlan` locks the plan→sidebar mapping
- [x] **Verified on a real `install <slug>` in a tmux pty**: renders the PIPELINE sidebar (`✓ Git identity`, `✓ Homebrew 24/24`, `✓ Applications 18/18`, `⠋ Dotfiles`, …) + streaming log; **zero "Step N" / "OpenBoot Installer" output**

## Scope

Covers every interactive TTY install that used RunContext — slug, preset, and file/RemoteConfig sources — so they all share the pipeline now. dry-run stays linear (shows what *would* happen).

## Cross-repo checklist

- [ ] Docs/content update in `openboot.dev`? — No
- [ ] CLI ↔ server API contract change? — No

## Notes for reviewer

- Builds on the #144 pipeline fixes (channel drain, ctx abort, race-free error handling) — same `RunPipeline` machinery.
- Pushed over HTTPS (gh token) — local SSH auth was down.

https://claude.ai/code/session_01HLoiSd2k9EJJ1HPjjDgUgo