### PR TITLE
fix(tui): stop saying "openboot" twice on the boot screen

### DIFF
--- a/internal/ui/tui/wizard/boot.go
+++ b/internal/ui/tui/wizard/boot.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 
 	"github.com/openbootdotdev/openboot/internal/brew"
 	"github.com/openbootdotdev/openboot/internal/config"
@@ -238,8 +237,11 @@ func (m Model) enterSelect(sel map[string]bool) (tea.Model, tea.Cmd) {
 func (m Model) bootBody(w, _ int) string {
 	const pad = "   "
 	var b []string
+	// No wordmark here: the title bar one row up already reads
+	// "▲ openboot vX.Y.Z". Repeating the name immediately below it said the
+	// same word twice and spent a row doing it. The tagline is the only part
+	// that adds anything, so the body opens with that.
 	b = append(b, "")
-	b = append(b, pad+wordmark()+" "+fg(cAccent).Render("▌"))
 	b = append(b, pad+fg(cDim3).Render("zero → dev-ready, in one command"))
 	b = append(b, "")
 
@@ -303,19 +305,6 @@ func (m Model) renderLoadout(i int, l loadout, w int) string {
 	return line
 }
 
-// wordmark renders "openboot" with the design's green gradient.
-func wordmark() string {
-	letters := []struct{ ch, hex string }{
-		{"o", "#166534"}, {"p", "#15803d"}, {"e", "#16a34a"}, {"n", "#22c55e"},
-		{"b", "#22c55e"}, {"o", "#4ade80"}, {"o", "#86efac"}, {"t", "#bbf7d0"},
-	}
-	var sb strings.Builder
-	for _, l := range letters {
-		sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(l.hex)).Bold(true).Render(l.ch))
-	}
-	return sb.String()
-}
-
 // estMinutes is a rough install-time estimate (~0.4 min/pkg), matching the
 // design's back-of-envelope figure.
 func estMinutes(pkgCount int) int {
@@ -356,10 +345,10 @@ func (m Model) bootHitTest(x, y int) int {
 		return -1
 	}
 	bodyRow := y - 1 // title bar is screen row 0
-	// Header: blank + wordmark + subtitle + blank = 4 body rows
+	// Header: blank + tagline + blank = 3 body rows
 	// Probes: len(m.probes) rows
 	// Footer before loadouts: blank + "Choose…" + blank = 3 body rows
-	loadoutStart := 4 + len(m.probes) + 3
+	loadoutStart := 3 + len(m.probes) + 3
 	idx := bodyRow - loadoutStart
 	if idx >= 0 && idx < len(m.loadouts) {
 		return idx

--- a/internal/ui/tui/wizard/wizard_test.go
+++ b/internal/ui/tui/wizard/wizard_test.go
@@ -239,9 +239,9 @@ func TestBootMouseClickPicksLoadout(t *testing.T) {
 	require.Equal(t, scrBoot, m.screen)
 	require.GreaterOrEqual(t, len(m.loadouts), 2)
 
-	// Click the second loadout row. Geometry: 4 header + 4 probes + 3 footer
-	// = loadouts start at body row 11 → screen row 12. Loadout 1 at row 13.
-	m = send(m, tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 10, Y: 13})
+	// Click the second loadout row. Geometry: 3 header + 4 probes + 3 footer
+	// = loadouts start at body row 10 → screen row 11. Loadout 1 at row 12.
+	m = send(m, tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 10, Y: 12})
 	assert.Equal(t, scrSelect, m.screen, "clicking a loadout enters the select screen")
 	assert.Equal(t, 1, m.loadCur, "click lands on loadout index 1")
 }
@@ -251,8 +251,8 @@ func TestBootMouseHoverHighlightsLoadout(t *testing.T) {
 	require.Equal(t, scrBoot, m.screen)
 	require.Equal(t, -1, m.hoverRow, "starts with no hover")
 
-	// Motion over the first loadout row (screen row 12) sets hoverRow.
-	m = send(m, tea.MouseMsg{Action: tea.MouseActionMotion, X: 10, Y: 12})
+	// Motion over the first loadout row (screen row 11) sets hoverRow.
+	m = send(m, tea.MouseMsg{Action: tea.MouseActionMotion, X: 10, Y: 11})
 	assert.Equal(t, 0, m.hoverRow, "hover over loadout 0")
 
 	// Motion off the loadout area clears it.


### PR DESCRIPTION
## What does this PR do?

Removes the boot screen's wordmark, which repeated the name the title bar had already printed one row above.

## Why?

Reported from a real run on v0.66.2:

```
▲ openboot v0.66.2                    setup     ← the frame names it
                                                 
   openboot ▌                                   ← …and the body names it again
   zero → dev-ready, in one command
```

The title bar is persistent chrome — it's on every screen, and it already carries the name and version. The wordmark was a splash element that added nothing except a second copy of the word and a spent row. The tagline is the only line in that block that says something, so the body now opens with it:

```
▲ openboot vdev                       setup

   zero → dev-ready, in one command

   ✓  probe   macOS 26.5.2 · Apple M2 Pro · 32 GB · arm64
   ✓  brew    Homebrew 6.0.11 — healthy
```

## Testing

- [x] `go vet ./...` passes
- [x] Relevant tests updated — `bootHitTest`'s geometry mirrors the render row-for-row, so removing a row moves the loadout rows up one. `TestBootMouseClickPicksLoadout` and `TestBootMouseHoverHighlightsLoadout` hardcode screen rows and both failed on the first run, which is exactly what they're there for; updated with the new geometry.
- [x] Tested locally — full L1 green (25 packages); golangci-lint clean; verified on a real pty that the boot screen renders as above and clicking a loadout still lands on the right one

## Notes for reviewer

`wordmark()` had no other caller, so it's deleted rather than left for `unused` to flag.